### PR TITLE
add image and image metadata fields

### DIFF
--- a/data_models/models.py
+++ b/data_models/models.py
@@ -23,9 +23,9 @@ class BaseModel(models.Model):
 
 
 class Image(BaseModel):
+    url = models.URLField(max_length=2048)   
     short_name = models.CharField(max_length=512, default='', blank=True)
     owner = models.CharField(max_length=512, default='', blank=True)
-    url = models.URLField(max_length=2048, null=True, blank=True)     
 
 
 class LimitedInfo(BaseModel):


### PR DESCRIPTION
**Motivation**
Images and image metadata are not currently supported by the database. Fields for this data need to be added to the data models.

**Potential Issues**
Some fields designated as image fields by the ADMG Requirements documents might be better stored in another format.
 
**Changes**
Add image url links and image metadata fields to the data models.
 
**Merge Ramifications**
None
 
**Trello**
[ADMG: Add Images to Data Models](https://trello.com/c/j38Wka7Q/718-admg-add-images-to-data-models)
