### PR TITLE
remove extra buttons from related items tree

### DIFF
--- a/admin_ui/templates/tags/related_changes.html
+++ b/admin_ui/templates/tags/related_changes.html
@@ -3,68 +3,64 @@
   <li class="nav-item">
     {% change_list_item object %}
     <ul class="list-unstyled ml-3">
-      
+
       {% for deployment in object.deployments %}
       <li class="nav-item">
         {% change_list_item deployment %}
         <ul class="list-unstyled ml-3">
 
           {% for significant_event in deployment.significant_events %}
-            <li class="nav-item">{% change_list_item significant_event %}</li>
+          <li class="nav-item">{% change_list_item significant_event %}</li>
           {% endfor %}
 
           <li class="nav-item">
-            <a href="{% url 'change-add' 'significantevent' %}?deployment={{ deployment.uuid }}" class="btn btn-info btn-sm">
+            <a href="{% url 'change-add' 'significantevent' %}?deployment={{ deployment.uuid }}"
+              class="btn btn-info btn-sm">
               Add related Significant Event
             </a>
           </li>
-        
+
           {% for iop in deployment.iops %}
           <li class="nav-item">
             {% change_list_item iop %}
-            
+
             <ul class="list-unstyled ml-3">
               {% for significant_event in iop.significant_events %}
-                <li class="nav-item">{% change_list_item significant_event %}</li>
+              <li class="nav-item">{% change_list_item significant_event %}</li>
               {% endfor %}
 
               <li class="nav-item">
-                <a href="{% url 'change-add' 'significantevent' %}?iop={{ iop.uuid }}&deployment={{ deployment.uuid }}" class="btn btn-info btn-sm">Add related Significant Event</a>
+                <a href="{% url 'change-add' 'significantevent' %}?iop={{ iop.uuid }}&deployment={{ deployment.uuid }}"
+                  class="btn btn-info btn-sm">Add related Significant Event</a>
               </li>
             </ul>
           </li>
           {% endfor %}
 
           <li class="nav-item">
-            <a href="{% url 'change-add' 'iop' %}?deployment={{ deployment.uuid }}" class="btn btn-info btn-sm">Add related IOP</a>
+            <a href="{% url 'change-add' 'iop' %}?deployment={{ deployment.uuid }}" class="btn btn-info btn-sm">Add
+              related IOP</a>
           </li>
-         
+
           {% for collection_period in deployment.collection_periods %}
           <li class="nav-item">
             {% change_list_item collection_period %}
             <ul class="list-unstyled ml-3">
-              
+
               {% for platform in collection_period.platforms %}
               <li class="nav-item">{% change_list_item platform %}</li>
-              {% empty %}
-              <li class="nav-item">
-                <a href="{% url 'change-add' 'platform' %}?collection_period={{ collection_period.uuid }}" class="btn btn-info btn-sm">Add related Platform</a>
-              </li>
               {% endfor %}
 
               {% for homebase in collection_period.homebases %}
               <li class="nav-item">{% change_list_item homebase %}</li>
-              {% empty %}
-              <li class="nav-item">
-                <a href="{% url 'change-add' 'homebase' %}?collection_period={{ collection_period.uuid }}" class="btn btn-info btn-sm">Add related Homebase</a>
-              </li>
               {% endfor %}
 
               {% for instrument in collection_period.instruments %}
               <li class="nav-item">{% change_list_item instrument %}</li>
               {% empty %}
               <li class="nav-item">
-                <a href="{% url 'change-add' 'instrument' %}?collection_period={{ collection_period.uuid }}" class="btn btn-info btn-sm">Add related Instrument</a>
+                <a href="{% url 'change-add' 'instrument' %}?collection_period={{ collection_period.uuid }}"
+                  class="btn btn-info btn-sm">Add related Instrument</a>
               </li>
               {% endfor %}
 
@@ -73,13 +69,15 @@
           {% endfor %}
 
           <li class="nav-item">
-            <a href="{% url 'change-add' 'collectionperiod' %}?deployment={{ deployment.uuid }}" class="btn btn-info btn-sm">Add related Collection Period</a>
+            <a href="{% url 'change-add' 'collectionperiod' %}?deployment={{ deployment.uuid }}"
+              class="btn btn-info btn-sm">Add related Collection Period</a>
           </li>
         </ul>
       </li>
       {% endfor %}
       <li class="nav-item">
-        <a href="{% url 'change-add' 'deployment' %}?object={{ object.uuid }}" class="btn btn-info btn-sm">Add related Deployment</a>
+        <a href="{% url 'change-add' 'deployment' %}?object={{ object.uuid }}" class="btn btn-info btn-sm">Add related
+          Deployment</a>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
## What has been built?
* "Add related homebase" and "Add related platforms" buttons where removed from the `related_changes` object because we they will not be created in this part of the website

## How was it done?
* deleting the relevant lines in `templates/admin/tags/related_changes.html`

## How can it be tested?
* None of pages of related items (Ex. http://localhost:8000/admin/drafts/d9099ddb-e05e-44b7-b71f-4d64608ad45e) should show those buttons anymore

## General Notes
This is a really small PR, mostly just to commit the changes Anthony and I made while working together before I move to a larger task.

My linter autosaves differently than the existing code branch so there are a bunch of unnecessary changes in this PR.  If anyone has suggestions how to fix that I'm all ears.