### PR TITLE
Only mark Summary link as active if we are strictly on root URL

### DIFF
--- a/admin_ui/templates/api_app/base.html
+++ b/admin_ui/templates/api_app/base.html
@@ -10,7 +10,7 @@
     <nav class="card">
       <ul class="nav flex-column list-group">
         <li class="nav-item list-group-item">
-          <a class="nav-link {% active_link 'summary' 'active' %}" href="{% url 'summary' %}">Summary</a>
+          <a class="nav-link {% active_link 'summary' 'active' strict=True %}" href="{% url 'summary' %}">Summary</a>
         </li>
         <li class="nav-item list-group-item">
           <a class="nav-link {% active_link 'change-list' 'active' %}" href="{% url 'change-list' %}">Campaigns</a>


### PR DESCRIPTION
Moving the Summary view to the root URL means that it is always considered "active".  I'm adding the `strict` flag to this route so that it is only marked active when the user is on the root URL and not any descendent URLs.