### PR TITLE
Keep table aligned with activity feed

### DIFF
--- a/admin_ui/templates/api_app/summary.html
+++ b/admin_ui/templates/api_app/summary.html
@@ -115,7 +115,7 @@
   <div class="row mx-3 my-5">
     <div class="col-8">
       <h3>My Drafts</h3>
-      <div class="mt-4">{% render_table table %}</div>
+      {% render_table table %}
     </div>
 
     <div class="col-4">


### PR DESCRIPTION
This is minor and arguably petty, but I think it's kind of annoying how the "My Drafts" table has is offset a few pixels lower than the "Inventory Activities" feed.

### Before

![image](https://user-images.githubusercontent.com/897290/111568443-5eb0ef80-8766-11eb-9943-b24654a0ce2d.png)


### After

![image](https://user-images.githubusercontent.com/897290/111568400-4a6cf280-8766-11eb-8562-69095b1ebf3e.png)
