### PR TITLE
Opt-out of client-side validation by default

### DIFF
--- a/admin_ui/templates/api_app/change_add_form.html
+++ b/admin_ui/templates/api_app/change_add_form.html
@@ -13,7 +13,6 @@
     <h1>Add new {{ content_type_name }} draft</h1>
   </div>
   <div class="col-auto px-0">
-    {# Using formnovalidate allows use to submit the form even if required fields are not provided #}
     <button class="btn btn-primary" form="model-form" formnovalidate>Save</button>
     <button class="btn btn-secondary" form="model-form">Validate & Save</button>
   </div>

--- a/admin_ui/templates/api_app/change_form.html
+++ b/admin_ui/templates/api_app/change_form.html
@@ -35,7 +35,8 @@
 
     <div class="col d-flex flex-row-reverse">
       <div class="px-1">
-        <button form="model-form" class="btn btn-primary" formnovalidate>Save</button>
+        <button class="btn btn-primary" form="model-form" formnovalidate>Save</button>
+        <button class="btn btn-secondary" form="model-form">Validate & Save</button>
       </div>
 
       <div class="px-1">


### PR DESCRIPTION
It turns out, the documentation on HTML has tons of interesting things in it.  Like, for example, did you know that if you add a `formnovalidate` attribute on a `button` element, you can skip client-side validation and submit a form ([source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button))?  This means that we don't need to disable the `required` properties via JS.  

This PR:

* utilizes the `formnovalidate` attribute to skip client-side validation when adding or editing a draft
* Fixes the "Submit" button on the add-draft form.  It also removes the redundant "Submit" button that was rendered at the bottom of the form and adds a "Validate & Save" button to allow someone to save after running client-side validation of the form.
* Removes JS that disabled the `required` attributes, as this is no longer needed.