### PR TITLE
Add lefthand border for selected accordian

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -25,3 +25,8 @@ td a {
 .cursor-pointer {
   cursor: pointer;
 }
+
+.list-group-item-primary {
+  padding-left: 15px; /* 21 - border-width */
+  border-left: 6px solid;
+}


### PR DESCRIPTION
This PR adds a wider lefthand border on the selected accordion element to better fit our wireframes:

![image](https://user-images.githubusercontent.com/897290/111512479-672d0a00-8715-11eb-8544-de4da3c9e61b.png)
![image](https://user-images.githubusercontent.com/897290/111512549-77dd8000-8715-11eb-8446-45178e2865de.png)
