### PR TITLE
Bug large cmr queries

### DIFF
--- a/cmr/cmr.py
+++ b/cmr/cmr.py
@@ -185,12 +185,14 @@ def bulk_cmr_query(query_parameter, query_value_list):
 
     # cmr can't handle big requests, like 303 concept_ids, all at once
     # this breaks them into sub requests of 50 at a time
-    chunk_size = 50
-    concept_id_list_chunks = [concept_id_list[i:i + chunk_size] for i in range(0, len(concept_id_list), chunk_size)]
-
+    CHUNK_SIZE = 50
+    current_index = 0
     concept_ids_responses = []
-    for concept_id_list in concept_id_list_chunks:
-        concept_ids_responses.extend(universal_query('echo_collection_id[]', concept_id_list))
+    length = len(concept_id_list)
+    while current_index < length:
+        concept_ids = concept_id_list[current_index:(current_index + CHUNK_SIZE)]
+        concept_ids_responses.extend(universal_query('echo_collection_id[]', concept_ids))
+        current_index += CHUNK_SIZE
 
     metadata_list = [concept_id_data for page in [response['items'] for response in concept_ids_responses] for concept_id_data in page]
 


### PR DESCRIPTION
**Motivation**
Some campaign doi generation tasks were failing due to unknown errors. 

This PR improves the error reporting from the CMR pipeline and fixes one bug concerning large CMR queries.

**Changes**
- slightly improved error reporting
- handler for large CMR queries

**Merge Ramifications**
 None

**Trello**
[ADMG: DOI Failure Bug (2)](https://trello.com/c/ho5kurgk/1081-admg-doi-failure-bug)