### PR TITLE
Enable Approval Actions button on campaign details page

### DIFF
--- a/admin_ui/templates/api_app/change_detail.html
+++ b/admin_ui/templates/api_app/change_detail.html
@@ -1,5 +1,6 @@
 {% extends "api_app/base.html" %}
 {% load change_extras %}
+{% load crispy_forms_tags %}
 {% load humanize %}
 
 {% block page %}
@@ -29,7 +30,17 @@
 
         <div class="col d-flex flex-row-reverse">
             <div class="px-1">
-                <button class="btn btn-primary">Submit for review (placeholder)</button> <!-- TODO: add onclick -->
+                <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" {% if not transition_form.fields.transition.choices|length %} disabled="true" {% endif %}
+                aria-expanded="false">Approval Actions
+                </button>
+
+                <div class="dropdown-menu">
+                <form action="{% url 'change-transition' object.uuid %}" method="post" class="px-4 py-3">
+                    {% csrf_token %}
+                    {{ transition_form | crispy }}
+                    <button class="btn btn-primary">Submit</button>
+                </form>
+                </div>
             </div>
 
             <div class="px-1">
@@ -48,7 +59,7 @@
                 <h4 class="mb-0">Deployments</h4>
                 <a class="btn btn-primary" href="{% url 'change-add' 'deployment' %}?campaign={{ object.uuid }}">+</a>
             </li>
-            {% for deployment in object_list %}
+            {% for deployment in deployments %}
             <li class="list-group-item list-group-item-action d-flex justify-content-between deployment cursor-pointer"
                 data-id="{{ deployment.uuid }}">
                 <div>
@@ -285,5 +296,10 @@
 
     // Select first
     $('.deployment:first').click()
+
+    // Make dropdown more resistant to accidental closes (https://stackoverflow.com/a/32922725/728583)
+    $(document).on('click', '.dropdown-menu', function (e) {
+    e.stopPropagation();
+    });
 </script>
 {% endblock %}

--- a/admin_ui/views.py
+++ b/admin_ui/views.py
@@ -155,17 +155,13 @@ class ChangeListView(django_tables2.SingleTableView):
 
 
 @method_decorator(login_required, name="dispatch")
-class ChangeDetailView(SingleObjectMixin, ListView):
+class ChangeDetailView(DetailView):
     model = Change
-    paginate_by = 25
     template_name = "api_app/change_detail.html"
+    queryset = Change.objects.filter(content_type__model=Campaign._meta.model_name)
 
-    def get(self, request, *args, **kwargs):
-        self.object = self.get_object(queryset=Change.objects.all())
-        return super().get(request, *args, **kwargs)
-
-    def get_queryset(self):
-        return (
+    def get_context_data(self, **kwargs):
+        deployments = (
             Change.objects.filter(
                 content_type__model="deployment",
                 update__campaign=str(self.kwargs[self.pk_url_kwarg]),
@@ -181,15 +177,17 @@ class ChangeDetailView(SingleObjectMixin, ListView):
             )
             .order_by(self.get_ordering())
         )
-
-    def get_context_data(self, **kwargs):
         return {
             **super().get_context_data(**kwargs),
+            "deployments": deployments,
+            "transition_form": forms.TransitionForm(
+                change=self.get_object(), user=self.request.user
+            ),
             "significant_events": (
                 Change.objects.select_related("content_type")
                 .filter(
                     content_type__model__iexact="significantevent",
-                    update__deployment__in=[str(d.uuid) for d in self.object_list],
+                    update__deployment__in=[str(d.uuid) for d in deployments],
                 )
                 .prefetch_related(
                     models.Prefetch(
@@ -216,7 +214,7 @@ class ChangeDetailView(SingleObjectMixin, ListView):
             "iops": Change.objects.select_related("content_type")
             .filter(
                 content_type__model__iexact="iop",
-                update__deployment__in=[str(d.uuid) for d in self.object_list],
+                update__deployment__in=[str(d.uuid) for d in deployments],
             )
             .prefetch_related(
                 models.Prefetch(
@@ -230,7 +228,7 @@ class ChangeDetailView(SingleObjectMixin, ListView):
             "collection_periods": Change.objects.select_related("content_type")
             .filter(
                 content_type__model__iexact="collectionperiod",
-                update__deployment__in=[str(d.uuid) for d in self.object_list],
+                update__deployment__in=[str(d.uuid) for d in deployments],
             )
             .prefetch_related(
                 models.Prefetch(
@@ -271,7 +269,7 @@ class ChangeCreateView(mixins.ChangeModelFormMixin, CreateView):
         }
 
     def get_success_url(self):
-        return reverse('change-form', args=[self.object.pk])
+        return reverse("change-form", args=[self.object.pk])
 
     def get_model_form_content_type(self) -> ContentType:
         if not hasattr(self, "model_form_content_type"):


### PR DESCRIPTION
## What has been built?
The button that previously said "Submit for Review (placeholder)" has been changed to be an approval button the same as the ones on the form pages that submits an approval for the campaign metadata.

### What isn't built
Eventually we want some kind of validation so that you can't submit a campaign for review without all of the dependent parts also being ready for review.  That check is not in place right now.

## How was it done?
* the html for both the button and the form was copied from `change_form.html` was copied into `change_detail.html`
* added a little jquery in `change_detail.html` to keep the form enabled even after you have selected a review option (by default it would close, making it hard to add notes)
* refactored `ChangeDetailView` to a `DetailView` instead of a `ListView`

## How can it be tested?
* Go to a campaign details page (Ex. http://localhost:8000/drafts/34dea2c0-b00e-40b2-bfd1-328df42bcfb7)
* select the Approval Actions drop down.  Make sure it has the actions appropriate to the status of the campaign and your user.
### Switching your user type
From `shell_plus`:
Become an admin:
```
u = User.objects.get(username='superuser')
u.is_superuser = True
u.save()
```
Become a staff user:
```
u = User.objects.get(username='superuser')  # input your username here
u.is_superuser = False
u.role = 2  # database code number for "staff"
u.save()
```