### PR TITLE
Mi/scroll multiselect inputs

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -17,7 +17,7 @@
 }
 
 select.selectmultiple {
-  overflow-x: auto;
+  overflow: auto;
   resize: auto;
 }
 

--- a/admin_ui/static/scss/admin.scss
+++ b/admin_ui/static/scss/admin.scss
@@ -19,7 +19,7 @@
 
 
 select.selectmultiple {
-  overflow-x: auto;
+  overflow: auto;
   resize: auto;
 }
 


### PR DESCRIPTION
This change adjusts the multiselect widgets in two ways:

1. If the text overflows on an axis, a scroll bar will be rendered
2. The input will be resizable in either axis

### Before

![image](https://user-images.githubusercontent.com/897290/118551445-13da3680-b71b-11eb-9a22-18e12756021e.png)


### After

![image](https://user-images.githubusercontent.com/897290/118551310-07ee7480-b71b-11eb-9822-4adb85f6927e.png)

