### PR TITLE
Reduce pagination to just 10 records per page

### DIFF
--- a/admin_ui/views.py
+++ b/admin_ui/views.py
@@ -276,7 +276,7 @@ class DoiFetchView(View):
 class DoiApprovalView(SingleObjectMixin, MultipleObjectMixin, FormView):
     form_class = forms.DoiFormSet
     template_name = "api_app/campaign_dois.html"
-    paginate_by = 100
+    paginate_by = 10
     campaign_queryset = Change.objects.of_type(Campaign)
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Goal: Decrease page load time by decreasing number of DOI records shown per page.

Conversation:
```
anthony: Stephanie (or Deborah or Camille), do you have a preference on the # of DOIs you’d like to see on the DOI Approval view?  The amount of rows shown directly impacts the speed at which the page loads, so finding the right balance is important.  100 may be too high, we could scale it back to something like 25 and get quicker page loads
stephanie: even 10 would be fine...if that's not too few?
anthony: Less is better from a technical perspective.  To me it comes down to the question of how much a user gains from seeing more together.  For example, is it important to compare a DOI against other DOIs present or is each one analyzed on its own?
stephanie: latter
anthony: okay, great, so I’ll do a quick codechange to limit the amount shown to 10 DOIs per page.
``` 
