### PR TITLE
Ensure NullBooleanField has initial value of None if not reviewed

### DIFF
--- a/admin_ui/views.py
+++ b/admin_ui/views.py
@@ -320,7 +320,7 @@ class DoiApprovalView(SingleObjectMixin, MultipleObjectMixin, FormView):
         return [
             {
                 "uuid": v["uuid"],
-                "keep": bool(v["update"].get("reviewed")),
+                "keep": "reviewed" in v["update"] or None,
                 **v["update"],
             }
             for v in paginated_queryset.values("uuid", "update")


### PR DESCRIPTION
This PR fixes a bug where the frontend was deleting "trashed" DOIs when submitting the DOI Approval form.  The core issue of the bug was the fact that the `keep` value of each form in the DOI formset was being set to `False`.  Because the initial data for each form was being set to `False`, Django's tooling didn't identify the form as being "changed".  Our code only looks at changed forms when we want to persist the data to our database, meaning that unchanged forms are ignored:

https://github.com/NASA-IMPACT/admg_webapp/blob/15fd211e7480aa19855ef44e9d6a68e545164a89/admin_ui/views.py#L330-L332

The correct course of action is for the `keep` value to be `None` by default.  This way, when a user sets the value to `false`, we identify the form as having changed and update our database with those changes.
