### PR TITLE
Persist "back" button on Change Transition form submissions

### DIFF
--- a/admin_ui/views.py
+++ b/admin_ui/views.py
@@ -1,4 +1,3 @@
-from urllib.parse import urlparse, parse_qs
 from typing import Dict
 
 from django.conf import settings


### PR DESCRIPTION
## What I'm changing

This PR ensures that the "← Back" button state is persisted after a user submits a Change Transition form.  

## How I did it

Previously, we would redirect a user to just the `path` property of the URL provided as the HTTP Referer. This stripped the URL of the `?back=...` query parameter which is used to render the correct link for the "← Back" button.  We will now use the entirety of the HTTP Referer as the success URL of the Change Transition form (or fallback to the parent `get_success_url()` if no referer is present).

## How you can test it

1. Navigate to any Campaign's DOI approval view
    ![image](https://user-images.githubusercontent.com/897290/122464848-8b96bd80-cf74-11eb-9788-ff34d8aed768.png)
2. Click into the "DOI form" from a DOI in the DOI table
    ![image](https://user-images.githubusercontent.com/897290/122464785-7de13800-cf74-11eb-84f8-67a2d1ab5383.png)
3. Transition that Change to some new state
    ![image](https://user-images.githubusercontent.com/897290/122464929-a36e4180-cf74-11eb-90cb-7acdc4e35a6a.png)
4. You should remain on the single-DOI change form.  Verify that the "← Back" button navigates you back to the DOI approval view.
![image](https://user-images.githubusercontent.com/897290/122464976-b54fe480-cf74-11eb-82ea-122050963704.png)

---

NOTE: Without the changes made to the `ManyToManyField` made in #159, loading the DOI form will be very slow.

https://github.com/NASA-IMPACT/admg_webapp/blob/2b210ea6e2aad90e9eacecbdfdb61411fb80fdb5/admin_ui/mixins.py#L38-L51