### PR TITLE
Prevent CustomDateField from rendering for DateTimeField

### DIFF
--- a/admin_ui/mixins.py
+++ b/admin_ui/mixins.py
@@ -42,6 +42,10 @@ def formfield_callback(f, **kwargs):
         kwargs.update({"widget": widgets.ImagePreviewWidget})
     elif isinstance(f, PolygonField):
         kwargs.update({"form_class": fields.BboxField})
+    elif isinstance(f, model_fields.DateTimeField):
+        # DateTimeField is a subclass of DateTime, we don't want to use 
+        # CustomDateField widget
+        pass  
     elif isinstance(f, model_fields.DateField):
         kwargs.update({"form_class": fields.CustomDateField})
     elif isinstance(f, model_fields.BooleanField):


### PR DESCRIPTION
The `DateTimeField` is a subclass of `DateField`:
```py
In [1]: from django.db import models as model_fields
In [2]: issubclass(model_fields.DateTimeField, model_fields.DateField)
Out[2]: True
```

As such, `isinstance(f, model_fields.DateField) == True` and we render the `CustomDateField` for forms containing `DateTimeField` instances.
https://github.com/NASA-IMPACT/admg_webapp/blob/419a64c6de6661cc9162ea0acd47d8302341c0c0/admin_ui/mixins.py#L45-L46

This fix adds a check before `isinstance(f, model_fields.DateField)` to see if the field is a `DateTimeField`, thereby avoiding the custom `form_class`.