### PR TITLE
change bucket to category

### DIFF
--- a/data_models/models.py
+++ b/data_models/models.py
@@ -300,7 +300,7 @@ class GcmdPlatform(BaseModel):
 
     def __str__(self):
         categories = (
-            self.bucket,
+            self.category,
             self.long_name,
             self.short_name
         )


### PR DESCRIPTION
**Bug Description**
Moving to various pages in the inventory threw a 500 error, specifically the instrument page.

**Solution**
Essentially a __str__ value was being calculated with a non-existent model field. Easy fix of replacing the wrong field with the correct field for the string value. 

**Notes**
However, this bug really confuses me, as it should have caused problems long before now, but for some reason didn't. I traced back through the last couple PRs, and this change was present in all of them, so I don't understand how we haven't seen this bug already.