### PR TITLE
Feature hidden fields

### DIFF
--- a/admg_webapp/templates/base.html
+++ b/admg_webapp/templates/base.html
@@ -75,7 +75,9 @@
             </li>
             {% if request.user.is_admg_admin %}
             <li class="nav-item mx-1">
-              <a class="nav-link btn btn-light" disabled >Deploy Website</a>
+              <form action="{% url 'mi-trigger-deploy' %}">
+                <input type="submit" value="Deploy Website" class="nav-link btn btn-light" />
+              </form>
             </li>
             {% endif %}
           </ul>

--- a/admin_ui/views.py
+++ b/admin_ui/views.py
@@ -78,7 +78,13 @@ from . import tables, forms, mixins, filters
 @login_required
 @user_passes_test(lambda user: user.is_admg_admin())
 def trigger_deploy(request):
-    workflow = settings.GITHUB_WORKFLOW
+    try:
+        workflow = settings.GITHUB_WORKFLOW
+    except AttributeError:
+        messages.add_message(
+            request, messages.ERROR, f"Failed to trigger deployment: Github workflow not specified in settings."
+        )
+        return HttpResponseRedirect(reverse("mi-summary"))
 
     response = requests.post(
         url=f"https://api.github.com/repos/{workflow['repo']}/actions/workflows/{workflow['id']}/dispatches",

--- a/api_app/api_documentation.py
+++ b/api_app/api_documentation.py
@@ -1,11 +1,10 @@
 from drf_yasg import openapi
 
 description = """
-<h2>Overview</h2>Welcome to the ADMG CASEI API Documentation. This page gives an overview of how to use the ADMG API as well as specific details for every endpoint and API method.
+<h2>Overview</h2>Welcome to the ADMG CASEI API Documentation. This page gives an overview of how to use the CASEI API as well as specific details for every endpoint and API method.
 <h2>Basic Structure</h2>CASEI is built on top of an SQL database with multiple tables that each contain fields and foriegn keys. Each endpoint in the API will point to a different table. 
-Requesting a bare endpoint, such as `/campaign/` will return a list of all the metadata for every campaign in the inventory.
-
-Below is a contrived example of the results from a campaign query, with ... indicating the continuation of additional metadata and additional campaigns. 
+Requesting a bare endpoint, such as `/campaign/` will return a list of all the metadata for every campaign in the inventory.<br>
+Below is a contrived example of the results from a campaign query, with ... indicating the continuation of additional metadata and additional campaigns.<br>
 ```
 {
     'success': True,
@@ -25,48 +24,50 @@ Below is a contrived example of the results from a campaign query, with ... indi
     ]
 }
 ```
-<h2>Response Content</h2>All API responses contain `success` boolean, a `message` string, and a `data` list. 
-<h4>success</h4>A `success` value of `True` only indicates that your reqeust was completed, and nothing on the backend threw an error. It does not indicate that a query returned any result data.
-Values of `False` are used to indicate that an action was not allowed, such as if you are attempting to POST to an endpoint and your token is not associated with an account that has the correct permisions. 
-<h4>message</h4>The message field will contain a description of the failure if `sucess` was returned as `True` and it will sometimes give a description about the action if it was successful.
-<h2>Using UUIDs</h2>As you can see from the above example, some fields return a human readable value, while others return a UUID. If you see a human readable value, then this is all the information contained
-in that field. However, if a UUID is listed, then this indicated this field is linked to an object with additional metadata.
-
-Every object in the database is uniquely identified with a UUID. This UUID is used throughout the API to reference objects that have been linked from other tables.
-So, if you want a particular campaign instead of all the campaigns, you can query using its specific UUID:
-
-`/campaign/d031186d-1a41-430b-ae02-1c76f4cfa441`
-
-Likewise, if there is a linked object within the metadata, such as `aliases` in our example, you can retrieve the linked object using the same method:
-
-`/alias/927479e5-b0c7-4aef-9d31-4a6850dea804`
-
-It is generally the case that if a linked field is singular, it will correspond perfectly with it's table, and if it is plural it will need to be singularized. So 'respositories' becomes 'repository', 'seasons' becomes 'season', and 'deployment' remains 'deployment'.
-<h2>Using short_name Searches</h2>The API also supports limited search functionality. Specifically, many endpoints allow
-
-`/endpoint?short_name=value`
-
-for example
-
-`/campaign?short_name=ACES`.
-<h2>Permissions: POST vs GET</h2>
-<h2>API Content and Field Names</h2>
-Below this section, there is a listing of every API endpoint and the available methods. If you are trying to figure out what data is available from the api, this is the place to look.
-If you click on an endpoint, it will enlarge and you will be able to see all the fields that are available.
-Each field has several values listed:
- - field name - the field name returned by the api
- - data type - for example string or integer
- - title - a human readable title for the field name
- - other parameters - values such as maxLength and minLength will appear here
- - description - A sentence or paragraph long description of what the field contains, and any clarifications that might be needed
-
+<h2>Using UUIDs</h2>Every object in the database is uniquely identified with a UUID. This UUID is used throughout the API to reference objects that have been linked from other tables.<br>
+So, if you want a particular campaign instead of all the campaigns, you can query using its specific UUID:<br>
+`/campaign/d031186d-1a41-430b-ae02-1c76f4cfa441`<br>
+As you can see from the above example, some fields return a human readable value, while others such as `aliases` return a UUID. If you see a human readable value, then this is all the information contained in that field. However, if a UUID is listed, then the field is linked to an object with additional metadata.<br>
+This object and its metadata can be retrieved by sending its UUID to the appropriate endpoint, as in the following example with aliases:
+`/alias/927479e5-b0c7-4aef-9d31-4a6850dea804`<br>
+Here, you can see that the field was named `aliases` however the endpoint queried was called `alias`. It is generally the case that if a linked field is singular, it will correspond perfectly with it's table, because this represents a one to one relationship. Meanwhile if the field is plural then it has a one/many to many relationship, and it will need to be singularized to obtain the table name. So 'repositories' becomes 'repository' and 'seasons' becomes 'season', while 'deployment' remains 'deployment'.<br>
+If you are ever in doubt, there is a full guide to every endpoint and field further in this document.<br>
+<h2>Using short_name Searches</h2>The API also supports limited search functionality. Specifically, many endpoints allow<br>
+`/endpoint?short_name=value`<br>
+for example<br>
+`/campaign?short_name=ACES`.<br>
+Specifically, the following endpoints and fields are searchable<br>
+<ul>
+    <li>`campaign`</li>
+        <ul>
+            <li>`short_name`, `long_name`, `description_short`, and `focus_phenomena`,</li>
+        </ul>
+    <li>`platform`</li>
+        <ul>
+            <li>`short_name`, `long_name`, and `description`</li>
+        </ul>
+    <li>`instrument`</li>
+        <ul>
+            <li>`short_name`, and `long_name`</li>
+        </ul>
+</ul>
+<h2>Permissions: POST vs GET</h2>Every endpoint is publicly accessible via the GET method, although some fields, such as `notes_internal` are for internal use only and will not be returned. The POST method is not publically accessible, and requires an authenticated user with a properly scoped token. If you have a need to use the POST method, please contact the ADMG team.<br>
+<h2>API Content and Field Names</h2>Below this section, there is a listing of every API endpoint and the available methods. If you are trying to figure out what data is available from the api, this is the place to look. If you click on an endpoint, it will enlarge and you will be able to see all the fields that are available.<br>
+Each field has several values listed:<br>
+<ul>
+    <li>field name: the field name returned by the api</li>
+    <li>data type: for example string or integer</li>
+    <li>title: a human readable title for the field name</li>
+    <li>other parameters: values such as maxLength and minLength will appear here</li>
+    <li>description: A sentence or paragraph long description of what the field contains, and any clarifications that might be needed</li>
+</ul>
 """
 
 api_info = openapi.Info(
-    title="ADMG API Documentation",
+    title="ADMG CASEI API Documentation",
     default_version="v1",
     description=description,
-    terms_of_service="https://www.google.com/policies/terms/",
-    contact=openapi.Contact(email="contact@snippets.local"),
-    license=openapi.License(name="BSD License"),
+    # terms_of_service="https://www.google.com/policies/terms/",
+    # contact=openapi.Contact(email="contact@snippets.local"),
+    # license=openapi.License(name="BSD License"),
 )


### PR DESCRIPTION
The database contains several fields which are meant to help the Inventory Team in the collection process but which are not intended to be available to the public. These fields were available by default through the GET endpoints. This PR restricts them to be only available through the POST endpoints (which are restricted to authenticated users using a properly scoped token).