### PR TITLE
Feature published update draft diff view

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -68,3 +68,7 @@ dt {
 .changed-item {
   background-color: rgba(170, 170, 0, 0.5);
 }
+
+.changed-item:disabled {
+  background-color: rgba(170, 170, 0, 0.5);
+}

--- a/admin_ui/templates/api_app/published_diff.html
+++ b/admin_ui/templates/api_app/published_diff.html
@@ -10,12 +10,9 @@
   </div>
 {% endblock header %}
 
-{% block object_details %}
-{% endblock object_details %}
-
 {% block actions %}
   <div class="px-1">
-    <button name="_validate" class="btn btn-primary" form="model-form">Save</button>
+    <button name="_validate" class="btn btn-primary" form="model-form" disabled={{ disable_save }}>Save</button>
     {% include "snippets/approval_dropdown.html" %}
   </div>
 
@@ -27,10 +24,10 @@
     {% csrf_token %}
     <div class="row">
       <div class="col-lg-6 col-sm-4">
-        New Side
+        New Version
       </div>
       <div class="col-lg-6 col-sm-4">
-        Original
+        Old Version
       </div>
     </div>
     {% for field1, field2 in editable_update_form|zip:noneditable_published_form %}

--- a/admin_ui/utils.py
+++ b/admin_ui/utils.py
@@ -37,7 +37,7 @@ def compare_values(old_item, new_item):
         old_item = str(old_item).strip()
         new_item = str(new_item).strip()
     else:
-        old_item = " ".join(old_item.strip().split())
-        new_item = " ".join(new_item.strip().split())
+        old_item = " ".join(str(old_item).strip().split())
+        new_item = " ".join(str(new_item).strip().split())
 
     return old_item == new_item

--- a/api_app/models.py
+++ b/api_app/models.py
@@ -389,8 +389,10 @@ class Change(models.Model):
             if self.action == UPDATE:
                 serializer = serializer_class(instance)
                 self.previous = {
-                    key: Change._get_processed_value(serializer.data.get(key))
-                        for key in self.update
+                    # might fail, if so revert back to:
+                    # key: Change._get_processed_value(serializer.data.get(key))
+                    key: Change._get_processed_value(getattr(instance, key))
+                    for key in self.update
                 }
 
     def get_latest_log(self):


### PR DESCRIPTION
Merge https://github.com/NASA-IMPACT/admg_webapp/pull/191 before merging this 

Trello card:
https://trello.com/c/W3IzGuA9/1259-admg-edit-drafts-13
Task: Published update drafts must show the old vs new data

Changed stuff

* reuse context generation
* incorporated published update drafts in the diff view
 * prevent from using save
 
