### PR TITLE
Cleanup filename

### DIFF
--- a/data_models/models.py
+++ b/data_models/models.py
@@ -57,7 +57,7 @@ class BaseModel(models.Model):
 
 
 def get_file_path(instance, path):
-    _, ext = os.path.splitext(urllib.parse.urlparse(path).path)
+    ext = os.path.splitext(urllib.parse.urlparse(path).path)[1]
     return f"{instance.uuid}.{ext}"
 
 


### PR DESCRIPTION
## What I'm changing
This PR fixes the `400` response bug we've been getting when attempting to upload images.  

## How I did it
The problem was due to the fact that the `path` arg provided to `get_file_path()` at time of upload is the full image URL including the AWS signature (e.g. `https://admg-test.s3.amazonaws.com/example-shrunk.png?AWSAccessKeyId=AKIAVDOH7H4HQBMNI3OC&Signature=%2BluoGy%2FzKKrBjkyX%2B783u%2BZ9Cf4%3D&Expires=1635189816`).


<details>

<summary><code>SuspiciousFileOperation: Storage tried to truncate away entire filename...</code></summary>

```
Environment:


Request Method: POST
Request URL: http://admgstaging.nasa-impact.net/drafts/add/image?_popup=1

Django Version: 3.1.3
Python Version: 3.8.5
Installed Applications:
['django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.sites',
 'django.contrib.messages',
 'django.contrib.staticfiles',
 'django.contrib.humanize',
 'admin_ui',
 'django.contrib.admin',
 'django.contrib.gis',
 'active_link',
 'allauth.account',
 'allauth.socialaccount',
 'allauth',
 'corsheaders',
 'crispy_forms',
 'django_celery_results',
 'django_sass',
 'django_tables2',
 'drf_yasg',
 'oauth2_provider',
 'rest_framework.authtoken',
 'rest_framework',
 'storages',
 'admg_webapp.users.apps.UsersConfig',
 'data_models.apps.DataModelsConfig',
 'api_app',
 'cmr']
Installed Middleware:
['corsheaders.middleware.CorsMiddleware',
 'django.middleware.security.SecurityMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.locale.LocaleMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'crum.CurrentRequestUserMiddleware']



Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 179, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/usr/local/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/utils/decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/app/web/admin_ui/views.py", line 450, in post
    return super().post(*args, **kwargs)
  File "/home/app/web/admin_ui/mixins.py", line 189, in post
    model_field.save(model_field.url, model_form.cleaned_data[name])
  File "/usr/local/lib/python3.8/site-packages/django/db/models/fields/files.py", line 87, in save
    self.name = self.storage.save(name, content, max_length=self.field.max_length)
  File "/usr/local/lib/python3.8/site-packages/django/core/files/storage.py", line 51, in save
    name = self.get_available_name(name, max_length=max_length)
  File "/usr/local/lib/python3.8/site-packages/storages/backends/s3boto3.py", line 584, in get_available_name
    return get_available_overwrite_name(name, max_length)
  File "/usr/local/lib/python3.8/site-packages/storages/utils.py", line 123, in get_available_overwrite_name
    raise SuspiciousFileOperation(

Exception Type: SuspiciousFileOperation at /drafts/add/image
Exception Value: Storage tried to truncate away entire filename "efb27706-ff6b-4f7e-b352-a49953923a70.jpegAWSAccessKeyIdASIAVDOH7H4HQHPOD5OISignature5zgw4EF2RI2FtK4ualnVBFAOJLUg3Dx-amz-security-tokenIQoJb3JpZ2luX2VjEMr2F2F2F2F2F2F2F2F2F2FwEaCXVzLWVhc3QtMSJIMEYCIQCv2360Iim2OHwU3xbisml1nTsMjdxCjs2FWAOlfNZ1JqQIhAOpXbm4e4v5Zd27baKOonbcJKhGmeZUvHyNem5S3jmJFKvoDCGIQBBoMMzUwOTk2MDg2NTQzIgw2Ef8rKovVVjRqz0Eq1wNmY6h0n2gXGaQO3hFjv32W2FboVDtXTmSYDWW23ZwWVLv0jGPWrRwKQNG176PHQBcmrrIBrKrEtl8yELN31gMiaiBWp8vlkYK2FHmqV27Ku2FiPV25jmPj2BCxHQ7AOVcBJtYMAjJ8CfeQrjf6NtbLr53YSGAEzSVR9JyySyTxpf4uvKJS1aSdKzCzeSw2FssKptKZRwl8RBCSuIQivAMPbEz7vSHlJjtRTZ6jFQD4pksIRJYtrR1Jye5uoQdKue2FZ3cL2FT7NDRj0NcgatHPaRBNoBhwxE2nm2BG3s4cskPOMK6zHdtvYl75RhkvDQPYkcVyZaY2FyXs2FGoE6KhQML5wVm626hGVamBQ1RoveQpUVVPrG0CAyJdZqC9SxzsDZyL2FZrMxLCoASIMyYtL2BkiBMXjbXT9257EsoCypPFEp0Nd8wgG6fKfwIUZXnJDP97bmzE8evbRi2F6b36BbJDABXhVkTyJ7oo55vPgwNyx5ztYnn2BztooG13G44RXVtzKI6mNpL6SMvj19z8CATNMB62Bja0lpCblvb6DHDp170x79j4NnO2RBpqBPty2VP2F79moIXXOszYmbIoIATikfai2BvNU2M2FC2BVvEdGoBO7vXutNg8juYabSOpY1AWqww1MjbiwY6pAHyhN17Krq4PEJlcbHSatqB2pB7Xn6A5tqii8R1tNjbGYKYufvjWPxBmx2yXetak951ghkYiRStRxOSg1SbG6I4G7kts42BhPXgGk7jKexrMY7s0WlRYf9jmSJ4hW4Ie0Mx4HSeOK0AVe2BUWUeYLnoDwG6oxJ0faX3CbbdBFBy1XXs2F19hmt8LuzOShoMIGnBUawlQAbR52BTmdFqUYQ7pjNB8fopmA3D3DExpires1635187459". Please make sure that the corresponding file field allows sufficient "max_length".
```

</details>


Running that path through `os.path.splitext()` returns an extension with the signature:

```py
>>> os.path.splitext('https://admg-test.s3.amazonaws.com/example-shrunk.png?AWSAccessKeyId=AKIAVDOH7H4HQBMNI3OC&Signature=%2BluoGy%2FzKKrBjkyX%2B783u%2BZ9Cf4%3D&Expires=1635189816')
('example-shrunk', '.png?AWSAccessKeyId=AKIAVDOH7H4HQBMNI3OC&Signature=%2BluoGy%2FzKKrBjkyX%2B783u%2BZ9Cf4%3D&Expires=1635189816')
```

With `urllib.path.parse()`, we can get the filename without the signature:

```py
>>> urllib.parse.urlparse('https://admg-test.s3.amazonaws.com/example-shrunk.png?AWSAccessKeyId=AKIAVDOH7H4HQBMNI3OC&Signature=%2BluoGy%2FzKKrBjkyX%2B783u%2BZ9Cf4%3D&Expires=1635189816').path
'/example-shrunk.png'
```

Now, running that through `os.path.splitext()`, we can get the cleaned extension:

```py
>>> os.path.splitext(urllib.parse.urlparse('https://admg-test.s3.amazonaws.com/example-shrunk.png?AWSAccessKeyId=AKIAVDOH7H4HQBMNI3OC&Signature=%2BluoGy%2FzKKrBjkyX%2B783u%2BZ9Cf4%3D&Expires=1635189816').path)
('/example-shrunk', '.png')
```

## Uncertainties

The current implementation will only include the last extension.  For example:

```py
>>> os.path.splitext('foo.tar.gz')
('foo.tar', '.gz')
```

If we want to keep all extensions, we should do something more like:

```py
>>> '.'.join('foo.tar.gz'.split('.')[1:])
'tar.gz'
```