### PR TITLE
Bugfix highlighting issue in foreign and many to many fields

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -61,6 +61,13 @@ dt {
   background-color: rgba(170, 170, 0, 0.5);
 }
 
-.changed-item:disabled {
+.changed-item :disabled {
+  background-color: rgba(170, 170, 0, 0.5);
+}
+
+.changed-item + span span.select2-container--default,
+.changed-item + span span.select2-container--disabled,
+.changed-item + span span.select2-selection--single,
+.changed-item + span span.select2-selection--multiple {
   background-color: rgba(170, 170, 0, 0.5);
 }

--- a/admin_ui/static/scss/admin.scss
+++ b/admin_ui/static/scss/admin.scss
@@ -53,10 +53,21 @@ dt {
   }
 }
 
-.changed-item {
-  background-color: rgba(170, 170, 0, 0.5);
-}
+$changed-item-color: rgba(170, 170, 0, 0.5);
 
-.changed-item:disabled {
-  background-color: rgba(170, 170, 0, 0.5);
+.changed-item {
+  background-color: $changed-item-color;
+
+  & :disabled {
+    background-color: $changed-item-color;
+  }
+
+  & + span {
+    span.select2-container--default,
+    span.select2-container--disabled,
+    span.select2-selection--single,
+    span.select2-selection--multiple{
+      background-color: $changed-item-color;
+    }
+  }
 }


### PR DESCRIPTION
The bug:
Update draft with updated foreign key value and many to many values was not highlighting the changed fields in the diff view. To replicate:
1) go to CDPIs
2) published view
3) click on create edit draft
4) change the campaign (many to many) and deployment (foreign key) value
5) view the newly created update draft in the diff view from draft list
6) notice that the changed values are not highlighted


The fix:
1) Add css for select element

Merge https://github.com/NASA-IMPACT/admg_webapp/pull/210 before this to view minimum code changes. or just look at the last  commit (693da21) 