### PR TITLE
Bump mypy version

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,7 +7,7 @@ psycopg2-binary==2.8.3  # https://github.com/psycopg/psycopg2
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy==0.720  # https://github.com/python/mypy
+mypy==0.910  # https://github.com/python/mypy
 pytest==5.0.1  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar
 


### PR DESCRIPTION
Installation of `requirements/local.txt` was failing locally on my machine (Apple M1, Python 3.9.9) with the following error:


<details>

<summary>Stacktrace</summary>

```py
Installing collected packages: typed-ast, mypy-extensions, mypy
    Running setup.py install for typed-ast ... error
    ERROR: Command errored out with exit status 1:
     command: /Users/alukach/Projects/devseed/admg/admg-backend/.venv/bin/python3.9 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-install-82fgbsja/typed-ast_1277af056b054801a2de3d7323cc69ac/setup.py'"'"'; __file__='"'"'/private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-install-82fgbsja/typed-ast_1277af056b054801a2de3d7323cc69ac/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-record-0cevnh1c/install-record.txt --single-version-externally-managed --compile --install-headers /Users/alukach/Projects/devseed/admg/admg-backend/.venv/include/site/python3.9/typed-ast
         cwd: /private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-install-82fgbsja/typed-ast_1277af056b054801a2de3d7323cc69ac/
    Complete output (69 lines):
    running install
    /Users/alukach/Projects/devseed/admg/admg-backend/.venv/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    running build
    running build_py
    creating build
    creating build/lib.macosx-11-arm64-3.9
    creating build/lib.macosx-11-arm64-3.9/typed_ast
    copying typed_ast/conversions.py -> build/lib.macosx-11-arm64-3.9/typed_ast
    copying typed_ast/__init__.py -> build/lib.macosx-11-arm64-3.9/typed_ast
    copying typed_ast/ast3.py -> build/lib.macosx-11-arm64-3.9/typed_ast
    copying typed_ast/ast27.py -> build/lib.macosx-11-arm64-3.9/typed_ast
    package init file 'ast3/tests/__init__.py' not found (or not a regular file)
    creating build/lib.macosx-11-arm64-3.9/typed_ast/tests
    copying ast3/tests/test_basics.py -> build/lib.macosx-11-arm64-3.9/typed_ast/tests
    running build_ext
    building '_ast27' extension
    creating build/temp.macosx-11-arm64-3.9
    creating build/temp.macosx-11-arm64-3.9/ast27
    creating build/temp.macosx-11-arm64-3.9/ast27/Custom
    creating build/temp.macosx-11-arm64-3.9/ast27/Parser
    creating build/temp.macosx-11-arm64-3.9/ast27/Python
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Custom/typed_ast.c -o build/temp.macosx-11-arm64-3.9/ast27/Custom/typed_ast.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/acceler.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/acceler.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/bitset.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/bitset.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/grammar.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/grammar.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/grammar1.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/grammar1.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/node.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/node.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/parser.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/parser.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/parsetok.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/parsetok.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Parser/tokenizer.c -o build/temp.macosx-11-arm64-3.9/ast27/Parser/tokenizer.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Python/Python-ast.c -o build/temp.macosx-11-arm64-3.9/ast27/Python/Python-ast.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Python/asdl.c -o build/temp.macosx-11-arm64-3.9/ast27/Python/asdl.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Python/ast.c -o build/temp.macosx-11-arm64-3.9/ast27/Python/ast.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Python/graminit.c -o build/temp.macosx-11-arm64-3.9/ast27/Python/graminit.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast27/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast27/Python/mystrtoul.c -o build/temp.macosx-11-arm64-3.9/ast27/Python/mystrtoul.o
    clang -bundle -undefined dynamic_lookup -L/opt/homebrew/opt/zlib/lib -I/opt/homebrew/opt/zlib/include build/temp.macosx-11-arm64-3.9/ast27/Custom/typed_ast.o build/temp.macosx-11-arm64-3.9/ast27/Parser/acceler.o build/temp.macosx-11-arm64-3.9/ast27/Parser/bitset.o build/temp.macosx-11-arm64-3.9/ast27/Parser/grammar.o build/temp.macosx-11-arm64-3.9/ast27/Parser/grammar1.o build/temp.macosx-11-arm64-3.9/ast27/Parser/node.o build/temp.macosx-11-arm64-3.9/ast27/Parser/parser.o build/temp.macosx-11-arm64-3.9/ast27/Parser/parsetok.o build/temp.macosx-11-arm64-3.9/ast27/Parser/tokenizer.o build/temp.macosx-11-arm64-3.9/ast27/Python/Python-ast.o build/temp.macosx-11-arm64-3.9/ast27/Python/asdl.o build/temp.macosx-11-arm64-3.9/ast27/Python/ast.o build/temp.macosx-11-arm64-3.9/ast27/Python/graminit.o build/temp.macosx-11-arm64-3.9/ast27/Python/mystrtoul.o -L/opt/homebrew/lib -L/opt/homebrew/opt/openssl@1.1/lib -L/opt/homebrew/opt/sqlite/lib -o build/lib.macosx-11-arm64-3.9/typed_ast/_ast27.cpython-39-darwin.so
    building '_ast3' extension
    creating build/temp.macosx-11-arm64-3.9/ast3
    creating build/temp.macosx-11-arm64-3.9/ast3/Custom
    creating build/temp.macosx-11-arm64-3.9/ast3/Parser
    creating build/temp.macosx-11-arm64-3.9/ast3/Python
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Custom/typed_ast.c -o build/temp.macosx-11-arm64-3.9/ast3/Custom/typed_ast.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/acceler.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/acceler.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/bitset.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/bitset.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/grammar.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/grammar.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/grammar1.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/grammar1.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/node.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/node.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/parser.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/parser.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/parsetok.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/parsetok.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Parser/tokenizer.c -o build/temp.macosx-11-arm64-3.9/ast3/Parser/tokenizer.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Python/Python-ast.c -o build/temp.macosx-11-arm64-3.9/ast3/Python/Python-ast.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Python/asdl.c -o build/temp.macosx-11-arm64-3.9/ast3/Python/asdl.o
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/homebrew/opt/zlib/include -Iast3/Include -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@1.1/include -I/opt/homebrew/opt/sqlite/include -I/Users/alukach/Projects/devseed/admg/admg-backend/.venv/include -I/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c ast3/Python/ast.c -o build/temp.macosx-11-arm64-3.9/ast3/Python/ast.o
    ast3/Python/ast.c:844:5: warning: code will never be executed [-Wunreachable-code]
        abort();
        ^~~~~
    ast3/Python/ast.c:4514:9: error: implicit declaration of function '_PyUnicode_DecodeUnicodeEscape' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        v = _PyUnicode_DecodeUnicodeEscape(s, len, NULL, &first_invalid_escape);
            ^
    ast3/Python/ast.c:4514:9: note: did you mean 'PyUnicode_DecodeUnicodeEscape'?
    /opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9/unicodeobject.h:588:23: note: 'PyUnicode_DecodeUnicodeEscape' declared here
    PyAPI_FUNC(PyObject*) PyUnicode_DecodeUnicodeEscape(
                          ^
    ast3/Python/ast.c:4514:7: warning: incompatible integer to pointer conversion assigning to 'PyObject *' (aka 'struct _object *') from 'int' [-Wint-conversion]
        v = _PyUnicode_DecodeUnicodeEscape(s, len, NULL, &first_invalid_escape);
          ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    2 warnings and 1 error generated.
    error: command '/usr/bin/clang' failed with exit code 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /Users/alukach/Projects/devseed/admg/admg-backend/.venv/bin/python3.9 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-install-82fgbsja/typed-ast_1277af056b054801a2de3d7323cc69ac/setup.py'"'"'; __file__='"'"'/private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-install-82fgbsja/typed-ast_1277af056b054801a2de3d7323cc69ac/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/3n/3dct2kb54xn1882dpbw0vbdh0000gn/T/pip-record-0cevnh1c/install-record.txt --single-version-externally-managed --compile --install-headers /Users/alukach/Projects/devseed/admg/admg-backend/.venv/include/site/python3.9/typed-ast Check the logs for full command output.
```

</details>

Upgrading mypy made this error go away.