### PR TITLE
Ensure diff highlighting works on disabled forms

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -61,7 +61,7 @@ dt {
 }
 
 .changed-item,
-:disabled.changed-item,
+.changed-item:disabled,
 .changed-item + span span.select2-container--default,
 .changed-item + span span.select2-container--disabled,
 .changed-item + span span.select2-selection--single,


### PR DESCRIPTION
#311 moved the highlighting from the disabled published data form to the input data form to avoid an issue where highlighting was not working on disabled fields. It turns out that this was probably a not-sufficient solution in that highlighting still does not work when the input data form is disabled (i.e. a published UPDATE draft).

This PR reworks the highlight CSS selection style to ensure that it is applied to disabled forms.

The core change is rewriting `.changed-item :disabled` as `:disabled.changed-item`.  The other changes are simply formatting.