### PR TITLE
apt-get update before install in tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Install GDAL
         run: |
+          sudo apt-get update
           sudo apt-get install libgdal-dev
 
       - uses: actions/cache@v2


### PR DESCRIPTION
closes #337 
## Description
All new PRs were failing the tests workflow at the `Install GDAL`. It's not clear why this suddenly stopped working, however here is the error.
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-gnutls-dev_7.68.0-1ubuntu2.7_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
Solution to add `apt-get update` is listed in the error itself, and seems to resolve the problem.