### PR TITLE
Re-enable Keep/Trash radio buttons on DOI view

### DIFF
--- a/admin_ui/templates/widgets/icon_radio.html
+++ b/admin_ui/templates/widgets/icon_radio.html
@@ -6,7 +6,7 @@
       autocomplete="off" 
       value="true"
       id="{{ widget.name }}_true"
-      disabled="{{ widget.readonly }}"
+      {% if widget.readonly %}disabled{% endif %}
       {% if widget.value == 'true' %}checked{% endif %}
     > 
     <label class="btn btn-primary mx-1 my-0" for="{{ widget.name }}_true">
@@ -19,7 +19,7 @@
       autocomplete="off"
       value="false"
       id="{{ widget.name }}_false"
-      disabled="{{ widget.readonly }}"
+      {% if widget.readonly %}disabled{% endif %}
       {% if widget.value == 'false' %}checked{% endif %}
     > 
     <label class="btn btn-primary mx-1 my-0" for="{{ widget.name }}_false">


### PR DESCRIPTION
Related: #342 
The disabled attribute is evaluated based on presence and not on a value assigned to it. In order to properly handle editable DOIs, we have to remove the attribute entirely. If `disabled` is present on the `input`, clicking the label will have no effect.

