### PR TITLE
convert instrument drafts previous.gcmd_phenomenas

### DIFF
--- a/data_models/migrations/0048_convert_draft_phenomenas_previous.py
+++ b/data_models/migrations/0048_convert_draft_phenomenas_previous.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+from api_app.models import Change
+
+
+def convert_phenomenas_to_phenomena(apps, schema_editor):
+    instrument_drafts = Change.objects.filter(content_type__model="instrument")
+    for instrument_draft in instrument_drafts:
+        if 'gcmd_phenomenas' in instrument_draft.previous.keys():
+            instrument_draft.previous['gcmd_phenomena'] = instrument_draft.previous.pop(
+                'gcmd_phenomenas'
+            )
+            instrument_draft.save(post_save=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("data_models", "0047_convert_draft_phenomenas")]
+
+    operations = [
+        migrations.RunPython(
+            convert_phenomenas_to_phenomena, reverse_code=migrations.RunPython.noop
+        )
+    ]


### PR DESCRIPTION
closes #362 

Some update drafts have a `.previous` field that carries the old `gcmd_phenomenas` reference. This migration updates all such references to prevent the MI from breaking.

The update itself is pretty straightforward, but the core concern in the review is whether saving the draft object will result in unintended database changes.