### PR TITLE
Remove autopublished count from each section count in GCMD sync email

### DIFF
--- a/kms/tasks.py
+++ b/kms/tasks.py
@@ -49,13 +49,12 @@ def email_gcmd_sync_results(gcmd_syncs):
                 "update_keywords": update_keywords,
                 "delete_keywords": delete_keywords,
                 "published_keywords": published_keywords,
-                "scheme_count": len(create_keywords)
-                + len(update_keywords)
-                + len(delete_keywords)
-                + len(published_keywords),
+                "scheme_count": len(create_keywords) + len(update_keywords) + len(delete_keywords),
             }
         )
-    total_count = sum([keyword['scheme_count'] for keyword in keywords_by_scheme])
+    total_count = sum([keyword['scheme_count'] for keyword in keywords_by_scheme]) + len(
+        autopublished_keywords
+    )
 
     email.gcmd_changes_email(
         email.Template(

--- a/kms/templates/email_style.html
+++ b/kms/templates/email_style.html
@@ -1,49 +1,10 @@
 <style>
-  p {
-    font-size: 14px;
-    font-weight: 400;
-    padding-left: 50px;
-  }
-
-  h1 {
-    font-size: 26px;
-  }
-
-  h2 {
-    padding-left: 25px;
-    font-size: 22px;
-  }
-
   h3 {
     padding-left: 25px;
-    font-size: 18px;
   }
 
-  .gcmd-keyword {
-    font-weight: 700;
-    font-size: 18px;
-    line-height: 24px;
-    padding-left: 40px;
-  }
-
-  .gcmd-inline-label {
-    font-weight: 700;
-    font-size: 14px;
-    line-height: 24px;
-  }
-
-  .gcmd-path {
-    font-size: 14px;
-    line-height: 24px;
-  }
-
-  .gcmd-changed {
-    color: #d6311c !important;
-  }
-
-  .gcmd-footer {
-    font-size: 10px;
-    color: rgba(68, 63, 63, 0.64);
-    text-indent: 15px;
+  h2.autopublished {
+    border-top: 1px dashed black;
+    padding-top: 1em;
   }
 </style>

--- a/kms/templates/gcmd_notification.html
+++ b/kms/templates/gcmd_notification.html
@@ -2,33 +2,29 @@
 {% load static %}
 {% include "email_style.html" %}
 
-<h1>
-  This is a notification that {{ total_count }} GCMD keywords were newly created, modified, or deleted.<br>
+<p>
+  This is a notification that <strong>{{ total_count }} GCMD keywords</strong> were newly created, modified, or deleted.<br>
   To review, go to <a href="https://{{ hostname }}{% url 'gcmd-list' %}">Review GCMD Changes.</a>
-</h1>
-
-<br>
-<br>
+</p>
 
 {% for scheme in keywords_by_scheme %}
-  <h1>{{ scheme.scheme|format_scheme_for_display }} ({{ scheme.scheme_count }})</h1>
+  <h2>{{ scheme.scheme|format_scheme_for_display }} ({{ scheme.scheme_count }})</h2>
 
   <!-- Created keywords -->
-  <h2> Created Keywords: {{ scheme.create_keywords | length }} </h2>
+  <h3>Created Keywords: {{ scheme.create_keywords | length }}</h3>
   
   <!-- Updated Keywords -->
-  <h2> Updated Keywords: {{ scheme.update_keywords | length }} </h2>
+  <h3>Updated Keywords: {{ scheme.update_keywords | length }}</h3>
   
   <!-- Deleted Keywords -->
-  <h2> Deleted Keywords: {{ scheme.delete_keywords | length }} </h2>
-  
+  <h3>Deleted Keywords: {{ scheme.delete_keywords | length }}</h3>
 {% endfor %}
 
 <!-- Auto-Published keywords -->
-<h1> Auto-Published Keywords: {{ autopublished_keywords | length }} </h1>
+<h2 class="autopublished">Auto-Published Keywords ({{ autopublished_keywords | length }})</h2>
 <p>These keywords were created, updated, or deleted but didn't have any CASEI objects associated
    with them. These keywords do not require an admin to review them.
 </p>
 {% for scheme in keywords_by_scheme %}
-  <h2>{{ scheme.scheme|format_scheme_for_display }}: ({{ scheme.published_keywords | length }})</h2>
+  <h3>{{ scheme.scheme|format_scheme_for_display }}: {{ scheme.published_keywords | length }}</h3>
 {% endfor %}

--- a/kms/templates/gcmd_notification.txt
+++ b/kms/templates/gcmd_notification.txt
@@ -17,8 +17,10 @@ Updated Keywords: {{ scheme.update_keywords | length }}
 Deleted Keywords: {{ scheme.delete_keywords | length }}
 {% endfor %}
 
+---
+
 {# Auto-Published keywords #}
-Auto-Published Keywords: {{ autopublished_keywords | length }}
+Auto-Published Keywords ({{ autopublished_keywords | length }})
 These keywords were created, updated, or deleted but didn't have any CASEI objects associated with them. These keywords do not require an admin to review them.
 
 {% for scheme in keywords_by_scheme %}


### PR DESCRIPTION
Since we don't list the number of autopublished records within each section of the email, it's confusing to include the count of autopublished records in each section's total count. I've removed that here. I've also updated some formatting and styling on the email, since we no longer include each updated GCMD keyword and everything else was rendered as a heading.