### PR TITLE
Specify the output_field on Coalesce to avoid error when source field…

### DIFF
--- a/admin_ui/views/change.py
+++ b/admin_ui/views/change.py
@@ -5,7 +5,7 @@ import django_tables2
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, OuterRef, Q, Value, aggregates, functions
+from django.db.models import CharField, Count, OuterRef, Q, Value, aggregates, functions
 from django.db.models.fields.json import KeyTextTransform
 from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
 from django.urls import reverse
@@ -460,7 +460,8 @@ class GcmdSyncListView(NotificationSidebar, SingleTableMixin, FilterView):
                         functions.NullIf(KeyTextTransform(attr, dictionary), Value(""))
                         for attr in gcmd.short_name_priority
                         for dictionary in ["update", "previous"]
-                    ]
+                    ],
+                    output_field=CharField(),
                 ),
                 resolved_records=functions.Coalesce(SubqueryCount(resolved_records), Value(0)),
                 affected_records=Count("recommendation", distinct=True),


### PR DESCRIPTION
… is JSONField and we expect to retrieve a string.


May resolve #444 

When accessing the gcmd sync list route, we get an error due to our use of `Coalesce`. We intend to retrieve a string, but are apparently retrieving data from both JSONFields and CharFields. I can't replicate this locally, so there may be something in the staging database causing the error, but this should at least force Coalesce to return a string.