### PR TITLE
ifequal was removed in Django 4

### DIFF
--- a/admin_ui/templates/api_app/change_gcmd.html
+++ b/admin_ui/templates/api_app/change_gcmd.html
@@ -89,7 +89,7 @@
                 name="choice-{{record.row.uuid}}"
                 value="True"
                 required
-                {% ifequal record.current_selection True %} checked {% endifequal %}
+                {% if record.current_selection %} checked {% endif %}
                 {% if action == 'Delete' %} disabled {% endif %}>
               <label for="connectChoice-{{record.row.short_name}}">Yes</label>
               <input
@@ -99,7 +99,7 @@
                 name="choice-{{record.row.uuid}}"
                 value="False"
                 required
-                {% ifequal record.current_selection False %} checked {% endifequal %}
+                {% if not record.current_selection %} checked {% endif %}
                 {% if action == 'Delete' %} disabled {% endif %}>
               <label for="ignoreChoice-{{record.row.short_name}}">No</label>
             </td>


### PR DESCRIPTION
From the [v4 release notes](https://docs.djangoproject.com/en/4.1/releases/4.0/#features-removed-in-4-0):

> The `{% ifequal %}` and `{% ifnotequal %}` template tags are removed.
