### PR TITLE
Enhc clean duplicate doi

### DIFF
--- a/clean_duplicate_doi.py
+++ b/clean_duplicate_doi.py
@@ -2,7 +2,7 @@ from api_app.models import Change
 from data_models.models import DOI, Campaign
 
 created_dois_drafts = Change.objects.of_type(DOI).filter(status=0)
-published_campaign_uuids = [str(uuid) for uuid in Campaign.objects.values_list("uuid",flat=True)]
+published_campaign_uuids = [str(uuid) for uuid in Campaign.objects.values_list("uuid", flat=True)]
 dois_to_delete = []
 for doi in created_dois_drafts:
     if any(uuid in doi.update.get('campaigns', []) for uuid in published_campaign_uuids):
@@ -10,4 +10,3 @@ for doi in created_dois_drafts:
 
 for doi in dois_to_delete:
     doi.delete()
-


### PR DESCRIPTION
Clean the duplicate DOI's which have the status 0 (Created) and iterate through all the Campaigns which are published and only appends unpublished DOI's to the list and then we delete them 