### PR TITLE
Avoid referencing non-existent model instances if a Deployment Create Draft is unpublished

### DIFF
--- a/admin_ui/templates/api_app/campaign_detail.html
+++ b/admin_ui/templates/api_app/campaign_detail.html
@@ -55,7 +55,7 @@
         </div>
       </li>
       {% for deployment in deployments %}
-      <li class="list-group-item list-group-item-action justify-content-between deployment cursor-pointer show-caret" data-id="{{ deployment.model_instance_uuid }}">
+      <li class="list-group-item list-group-item-action justify-content-between deployment cursor-pointer show-caret" data-id="{% firstof deployment.model_instance_uuid or deployment.uuid %}">
         {% include "snippets/campaign_accordian_cards/deployment.html" with change=deployment %}
       </li>
       {% endfor %}


### PR DESCRIPTION
If a deployment has a model_instance_uuid, use that when creating related objects. If it does not, use the UUID of the draft.

For unpublished create drafts, this should create the correct reference, since the UUID of that draft will be persisted to the Deployment model when it is published.