### PR TITLE
Create unpublished drafts api route

### DIFF
--- a/api_app/serializers.py
+++ b/api_app/serializers.py
@@ -34,7 +34,7 @@ class ImageSerializer(serializers.ModelSerializer):
 class UnpublishedSerializer(serializers.ModelSerializer):
     class Meta:
         model = Change
-        fields = ["update", "uuid"]
+        fields = ["update", "uuid", "content_type", "status"]
 
 
 class ValidationSerializer(serializers.Serializer):

--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -20,7 +20,7 @@ from .views.change_view import (
 from .views.generic_views import GenericCreateGetAllView, GenericPutPatchDeleteView
 from .views.image_view import ImageListCreateAPIView, ImageRetrieveDestroyAPIView
 from .views.validation_view import JsonValidationView
-from .views.unpublished_view import UnpublishedListCreateAPIView
+from .views.unpublished_view import UnpublishedChangesView
 
 info = api_info
 
@@ -78,7 +78,7 @@ for url in urls:
 urlpatterns += [
     path("approval_log", ApprovalLogListView.as_view(), name="approval_log_list"),
     path("change_request", ChangeListView.as_view(), name="change_request_list"),
-    path("unpublished_drafts", UnpublishedListCreateAPIView.as_view(), name="unpublished"),
+    path("unpublished_drafts", UnpublishedChangesView.as_view(), name="unpublished"),
     path(
         "change_request/<str:uuid>",
         ChangeListUpdateView.as_view(),

--- a/api_app/views/unpublished_view.py
+++ b/api_app/views/unpublished_view.py
@@ -1,5 +1,4 @@
 from rest_framework.generics import ListAPIView
-from rest_framework.parsers import MultiPartParser
 
 from api_app.serializers import UnpublishedSerializer
 
@@ -8,12 +7,11 @@ from .view_utils import handle_exception
 from .generic_views import GetPermissionsMixin
 
 
-class UnpublishedListCreateAPIView(GetPermissionsMixin, ListAPIView):
+class UnpublishedChangesView(GetPermissionsMixin, ListAPIView):
     """
-    List images and create an image object
+    Lists unpublished changes with certain status and action
     """
 
-    parser_class = (MultiPartParser,)
     queryset = Change.objects.filter(
         status=Change.Statuses.IN_ADMIN_REVIEW, action=Change.Actions.CREATE
     )
@@ -22,7 +20,3 @@ class UnpublishedListCreateAPIView(GetPermissionsMixin, ListAPIView):
     @handle_exception
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
-
-    @handle_exception
-    def post(self, request, *args, **kwargs):
-        return self.create(request, *args, **kwargs)


### PR DESCRIPTION
### What I'm adding
I'm adding another route to the api model. I create another custom route to fetch all unpublished drafts that are currently in admin_review.

### How you can test it
You can look at the interactive swagger api documentation and try it out there. Or, alternatively you can go directly to the route at `/api/unpublished_drafts` and view the raw JSON response.

<img width="531" alt="Screen Shot 2023-06-13 at 12 34 11 PM" src="https://github.com/NASA-IMPACT/admg-backend/assets/31222040/eb5b76e1-b153-456e-b931-f9916dc23a6d">
