### PR TITLE
Rm unused field

### DIFF
--- a/data_models/models.py
+++ b/data_models/models.py
@@ -534,7 +534,6 @@ class Campaign(DataModel):
         verbose_name="Data Repository(ies)",
         help_text="Data repository (assigned archive repository) for the campaign (typically a NASA DAAC)",
     )
-    number_data_products = models.PositiveIntegerField(null=True, blank=True)
     data_volume = models.CharField(
         max_length=256,
         null=True,


### PR DESCRIPTION
We have a `number_data_products` field declared on the `Campaign` model, however, it is then overridden with a model property:

https://github.com/NASA-IMPACT/admg-backend/blob/988017cba6e64916d5d0031056dbced2d1e7e388/data_models/models.py#L582-L584

A quick test demonstrates that properties override fields:

```py
In [1]: class Foo:
   ...:     x = 1
   ...:     @property
   ...:     def x(self):
   ...:         return 2
   ...: 

In [2]: Foo().x
Out[2]: 2
```

This is also confirmed by the fact that removing the field results in no migration detected by Django.  However, removing the property will create a migration to add a field to the `Campaign` model.