### PR TITLE
Same changes as Eds PR but without merge conflicts

### DIFF
--- a/app/admin_ui/tables/tables.py
+++ b/app/admin_ui/tables/tables.py
@@ -589,7 +589,7 @@ class CampaignChangeListTable(LimitedTableBase):
                     "canonical_uuid": record.uuid,
                     # this property is coming from an annotation on the inital query
                     "draft_uuid": record.draft_uuid,
-                    "model": record.model_name.lower(),
+                    "model": camel_to_snake(record.model_name),
                 },
             ),
             label=record.latest_update.get('short_name') or '---',
@@ -619,7 +619,7 @@ class PlatformChangeListTable(LimitedTableBase):
                     "canonical_uuid": record.uuid,
                     # this property is coming from an annotation on the inital query
                     "draft_uuid": record.draft_uuid,
-                    "model": record.model_name.lower(),
+                    "model": camel_to_snake(record.model_name),
                 },
             ),
             label=record.update.get('short_name') or '---',
@@ -641,7 +641,7 @@ class InstrumentChangeListTable(LimitedTableBase):
                     "canonical_uuid": record.uuid,
                     # this property is coming from an annotation on the inital query
                     "draft_uuid": record.draft_uuid,
-                    "model": record.model_name.lower(),
+                    "model": camel_to_snake(record.model_name),
                 },
             ),
             label=record.update.get('short_name') or '---',
@@ -674,7 +674,7 @@ class ChangeSummaryTable(DraftTableBase):
                     "canonical_uuid": record.model_instance_uuid or record.uuid,
                     # TODO this change object has not property draft uuid
                     "draft_uuid": record.uuid,
-                    "model": record.model_name.lower(),
+                    "model": camel_to_snake(record.model_name),
                 },
             ),
             label=record.update.get('short_name') or '---',
@@ -950,7 +950,7 @@ class ImageChangeListTable(DraftTableBase):
                     "canonical_uuid": record.uuid,
                     # this property is coming from an annotation on the inital query
                     "draft_uuid": record.draft_uuid,
-                    "model": record.model_name.lower(),
+                    "model": camel_to_snake(record.model_name),
                 },
             ),
             label=record.update.get('short_name') or '---',
@@ -970,7 +970,7 @@ class DraftHistoryTable(tables.Table):
             lambda record: reverse(
                 "historical-detail",
                 kwargs={
-                    "model": record.model_name.lower(),
+                    "model": camel_to_snake(record.model_name),
                     "draft_uuid": record.uuid,
                     "canonical_uuid": record.model_instance_uuid or record.uuid,
                 },


### PR DESCRIPTION
We expect model names to be snake case, but were generating links with the lowercase version.

Resolves https://github.com/NASA-IMPACT/admg-backend/issues/548