### PR TITLE
Bugfix/555 table to detail view abnormalities

### DIFF
--- a/app/admin_ui/tables/published.py
+++ b/app/admin_ui/tables/published.py
@@ -29,8 +29,6 @@ from data_models.models import (
     WebsiteType,
 )
 
-from .tables import ConditionalValueColumn, ShortNamefromUUIDColumn
-
 
 class LimitedTableBase(tables.Table):
     long_name = tables.Column(verbose_name="Long Name", accessor="long_name")
@@ -46,13 +44,15 @@ class LimitedTableBase(tables.Table):
 
 
 class IOPPublishedTable(tables.Table):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('IOP'))),
         verbose_name="Short Name",
         accessor="short_name",
     )
-    deployment = ShortNamefromUUIDColumn(
-        verbose_name="Deployment", model=Deployment, accessor="deployment"
+    deployment = tables.Column(
+        verbose_name="Deployment",
+        # model=Deployment,
+        accessor="deployment",
     )
     start_date = tables.Column(verbose_name="Start Date", accessor="start_date")
     end_date = tables.Column(verbose_name="End Date", accessor="end_date")
@@ -67,7 +67,7 @@ class IOPPublishedTable(tables.Table):
 
 
 class SignificantEventPublishedTable(tables.Table):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('SignificantEvent')),
@@ -75,8 +75,10 @@ class SignificantEventPublishedTable(tables.Table):
         verbose_name="Short Name",
         accessor="short_name",
     )
-    deployment = ShortNamefromUUIDColumn(
-        verbose_name="Deployment", model=Deployment, accessor="deployment"
+    deployment = tables.Column(
+        verbose_name="Deployment",
+        # model=Deployment,
+        accessor="deployment",
     )
     start_date = tables.Column(verbose_name="Start Date", accessor="start_date")
     end_date = tables.Column(verbose_name="End Date", accessor="end_date")
@@ -91,19 +93,25 @@ class SignificantEventPublishedTable(tables.Table):
 
 
 class CollectionPeriodPublishedTable(tables.Table):
-    deployment = ShortNamefromUUIDColumn(
+    deployment = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A('uuid'), model=camel_to_snake('CollectionPeriod')),
         ),
-        model=Deployment,
+        # model=Deployment,
         verbose_name="Deployment",
         accessor="deployment",
     )
 
-    platform = ShortNamefromUUIDColumn(verbose_name="Platform", model=Platform, accessor="platform")
-    instruments = ShortNamefromUUIDColumn(
-        verbose_name="Instruments", model=Instrument, accessor="instruments"
+    platform = tables.Column(
+        verbose_name="Platform",
+        # model=Platform,
+        accessor="platform",
+    )
+    instruments = tables.Column(
+        verbose_name="Instruments",
+        # model=Instrument,
+        accessor="instruments",
     )
 
     def __init__(self, data, *args, **kwargs):
@@ -120,20 +128,26 @@ class CollectionPeriodPublishedTable(tables.Table):
 
 
 class DOIPublishedTable(tables.Table):
-    concept_id = ConditionalValueColumn(
+    concept_id = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('DOI'))),
         verbose_name="Concept ID",
         accessor="concept_id",
     )
     long_name = tables.Column(verbose_name="Long Name", accessor="long_name")
-    campaigns = ShortNamefromUUIDColumn(
-        verbose_name="Campaigns", model=Campaign, accessor="campaigns"
+    campaigns = tables.Column(
+        verbose_name="Campaigns",
+        # model=Campaign,
+        accessor="campaigns",
     )
-    platforms = ShortNamefromUUIDColumn(
-        verbose_name="Platforms", model=Platform, accessor="platforms"
+    platforms = tables.Column(
+        verbose_name="Platforms",
+        # model=Platform,
+        accessor="platforms",
     )
-    instruments = ShortNamefromUUIDColumn(
-        verbose_name="Instruments", model=Instrument, accessor="instruments"
+    instruments = tables.Column(
+        verbose_name="Instruments",
+        # model=Instrument,
+        accessor="instruments",
     )
 
     def __init__(self, data, *args, **kwargs):
@@ -148,12 +162,16 @@ class DOIPublishedTable(tables.Table):
 
 
 class DeploymentPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Deployment'))),
         verbose_name="Short Name",
         accessor="short_name",
     )
-    campaign = ShortNamefromUUIDColumn(verbose_name="Campaign", model=Campaign, accessor="campaign")
+    campaign = tables.Column(
+        verbose_name="Campaign",
+        # model=Campaign,
+        accessor="campaign",
+    )
     start_date = tables.Column(verbose_name="Start Date", accessor="start_date")
     end_date = tables.Column(verbose_name="End Date", accessor="end_date")
 
@@ -167,7 +185,7 @@ class DeploymentPublishedTable(LimitedTableBase):
 
 
 class PlatformTypePublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('PlatformType')),
@@ -184,7 +202,7 @@ class PlatformTypePublishedTable(LimitedTableBase):
 
 
 class MeasurementTypePublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('MeasurementType')),
@@ -201,7 +219,7 @@ class MeasurementTypePublishedTable(LimitedTableBase):
 
 
 class MeasurementStylePublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('MeasurementStyle')),
@@ -218,7 +236,7 @@ class MeasurementStylePublishedTable(LimitedTableBase):
 
 
 class HomeBasePublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('HomeBase'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -232,7 +250,7 @@ class HomeBasePublishedTable(LimitedTableBase):
 
 
 class FocusAreaPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('FocusArea'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -246,7 +264,7 @@ class FocusAreaPublishedTable(LimitedTableBase):
 
 
 class SeasonPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Season'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -260,7 +278,7 @@ class SeasonPublishedTable(LimitedTableBase):
 
 
 class RepositoryPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Repository'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -274,7 +292,7 @@ class RepositoryPublishedTable(LimitedTableBase):
 
 
 class MeasurementRegionPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('MeasurementRegion')),
@@ -292,7 +310,7 @@ class MeasurementRegionPublishedTable(LimitedTableBase):
 
 
 class GeographicalRegionPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('GeographicalRegion')),
@@ -310,7 +328,7 @@ class GeographicalRegionPublishedTable(LimitedTableBase):
 
 
 class GeophysicalConceptPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('GeophysicalConcept')),
@@ -328,7 +346,7 @@ class GeophysicalConceptPublishedTable(LimitedTableBase):
 
 
 class PartnerOrgPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('PartnerOrg'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -342,7 +360,7 @@ class PartnerOrgPublishedTable(LimitedTableBase):
 
 
 class WebsiteTypePublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('WebsiteType')),
@@ -359,7 +377,7 @@ class WebsiteTypePublishedTable(LimitedTableBase):
 
 
 class CampaignPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Campaign'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -373,7 +391,7 @@ class CampaignPublishedTable(LimitedTableBase):
 
 
 class PlatformPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Platform'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -387,7 +405,7 @@ class PlatformPublishedTable(LimitedTableBase):
 
 
 class InstrumentPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Instrument'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -401,7 +419,7 @@ class InstrumentPublishedTable(LimitedTableBase):
 
 
 class WebsitePublishedTable(tables.Table):
-    title = ConditionalValueColumn(
+    title = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Website'))),
         verbose_name="Title",
         accessor="title",
@@ -416,7 +434,7 @@ class WebsitePublishedTable(tables.Table):
 
 
 class AliasPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Alias'))),
         verbose_name="Short Name",
         accessor="short_name",
@@ -431,7 +449,7 @@ class AliasPublishedTable(LimitedTableBase):
 
 
 class GcmdProjectPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('GcmdProject')),
@@ -448,7 +466,7 @@ class GcmdProjectPublishedTable(LimitedTableBase):
 
 
 class GcmdInstrumentPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('GcmdInstrument')),
@@ -479,7 +497,7 @@ class GcmdInstrumentPublishedTable(LimitedTableBase):
 
 
 class GcmdPlatformPublishedTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('GcmdPlatform')),
@@ -496,7 +514,7 @@ class GcmdPlatformPublishedTable(LimitedTableBase):
 
 
 class GcmdPhenomenonPublishedTable(tables.Table):
-    variable_3 = ConditionalValueColumn(
+    variable_3 = tables.Column(
         linkify=(
             "published-detail",
             dict(pk=tables.A("uuid"), model=camel_to_snake('GcmdPhenomenon')),
@@ -517,7 +535,7 @@ class GcmdPhenomenonPublishedTable(tables.Table):
 
 
 class ImagePublishedTable(tables.Table):
-    title = ConditionalValueColumn(
+    title = tables.Column(
         linkify=("published-detail", dict(pk=tables.A("uuid"), model=camel_to_snake('Image'))),
         verbose_name="Title",
         accessor="title",

--- a/app/admin_ui/tables/tables.py
+++ b/app/admin_ui/tables/tables.py
@@ -17,14 +17,15 @@ from data_models.models import (
 from api_app.models import ApprovalLog
 
 
-class ConditionalValueColumn(tables.Column):
+class BackupValueColumn(tables.Column):
     """
     Attempt to retrieve a value from a record. If that value is not available (ie is None),
     attempt to retrieve the value from a backup location.
     """
-    def __init__(self, update_accessor=None, **kwargs):
+
+    def __init__(self, *, backup_accessor: str, **kwargs):
         super().__init__(**kwargs, empty_values=())
-        self.update_accessor = update_accessor
+        self.backup_accessor = backup_accessor
 
     def _get_processed_value(self, value):
         if value.__class__.__name__ == "ManyRelatedManager":
@@ -47,9 +48,8 @@ class ConditionalValueColumn(tables.Column):
         return self._get_processed_value(value) or "---"
 
 
-
-class ShortNamefromUUIDColumn(ConditionalValueColumn):
-    def __init__(self, model=None, **kwargs):
+class ShortNamefromUUIDColumn(BackupValueColumn):
+    def __init__(self, *, model, **kwargs):
         super().__init__(**kwargs)
         self.model = model
 
@@ -206,16 +206,16 @@ class DraftTableBase(tables.Table):
 
 
 class LimitedTableBase(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    long_name = ConditionalValueColumn(
+    long_name = BackupValueColumn(
         verbose_name="Long Name",
         accessor="latest_update__long_name",
-        update_accessor="content_object.long_name",
+        backup_accessor="content_object.long_name",
     )
 
     initial_fields = ("short_name", "long_name")
@@ -226,27 +226,27 @@ class LimitedTableBase(DraftTableBase):
 
 
 class IOPChangeListTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
     deployment = ShortNamefromUUIDColumn(
         verbose_name="Deployment",
         model=Deployment,
         accessor="update__deployment",
-        update_accessor="content_object.deployment",
+        backup_accessor="content_object.deployment",
     )
-    start_date = ConditionalValueColumn(
+    start_date = BackupValueColumn(
         verbose_name="Start Date",
         accessor="update__start_date",
-        update_accessor="content_object.start_date",
+        backup_accessor="content_object.start_date",
     )
-    end_date = ConditionalValueColumn(
+    end_date = BackupValueColumn(
         verbose_name="End Date",
         accessor="update__end_date",
-        update_accessor="content_object.end_date",
+        backup_accessor="content_object.end_date",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -261,27 +261,27 @@ class IOPChangeListTable(DraftTableBase):
 
 
 class SignificantEventChangeListTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
     deployment = ShortNamefromUUIDColumn(
         verbose_name="Deployment",
         model=Deployment,
         accessor="update__deployment",
-        update_accessor="content_object.deployment",
+        backup_accessor="content_object.deployment",
     )
-    start_date = ConditionalValueColumn(
+    start_date = BackupValueColumn(
         verbose_name="Start Date",
         accessor="update__start_date",
-        update_accessor="content_object.start_date",
+        backup_accessor="content_object.start_date",
     )
-    end_date = ConditionalValueColumn(
+    end_date = BackupValueColumn(
         verbose_name="End Date",
         accessor="update__end_date",
-        update_accessor="content_object.end_date",
+        backup_accessor="content_object.end_date",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -302,20 +302,20 @@ class CollectionPeriodChangeListTable(DraftTableBase):
         model=Deployment,
         verbose_name="Deployment",
         accessor="update__deployment",
-        update_accessor="content_object.deployment",
+        backup_accessor="content_object.deployment",
     )
 
     platform = ShortNamefromUUIDColumn(
         verbose_name="Platform",
         model=Platform,
         accessor="update__platform",
-        update_accessor="content_object.platform",
+        backup_accessor="content_object.platform",
     )
     instruments = ShortNamefromUUIDColumn(
         verbose_name="Instruments",
         model=Instrument,
         accessor="update__instruments",
-        update_accessor="content_object.instruments",
+        backup_accessor="content_object.instruments",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -325,34 +325,34 @@ class CollectionPeriodChangeListTable(DraftTableBase):
 
 
 class DOIChangeListTable(DraftTableBase):
-    concept_id = ConditionalValueColumn(
+    concept_id = BackupValueColumn(
         verbose_name="Concept ID",
         accessor="update__concept_id",
-        update_accessor="content_object.concept_id",
+        backup_accessor="content_object.concept_id",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    long_name = ConditionalValueColumn(
+    long_name = BackupValueColumn(
         verbose_name="Long Name",
         accessor="update__long_name",
-        update_accessor="content_object.long_name",
+        backup_accessor="content_object.long_name",
     )
     campaigns = ShortNamefromUUIDColumn(
         verbose_name="Campaigns",
         model=Campaign,
         accessor="update__campaigns",
-        update_accessor="content_object.campaigns",
+        backup_accessor="content_object.campaigns",
     )
     platforms = ShortNamefromUUIDColumn(
         verbose_name="Platforms",
         model=Platform,
         accessor="update__platforms",
-        update_accessor="content_object.platforms",
+        backup_accessor="content_object.platforms",
     )
     instruments = ShortNamefromUUIDColumn(
         verbose_name="Instruments",
         model=Instrument,
         accessor="update__instruments",
-        update_accessor="content_object.instruments",
+        backup_accessor="content_object.instruments",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -372,17 +372,17 @@ class DeploymentChangeListTable(LimitedTableBase):
         verbose_name="Campaign",
         model=Campaign,
         accessor="update__campaign",
-        update_accessor="content_object.campaign",
+        backup_accessor="content_object.campaign",
     )
-    start_date = ConditionalValueColumn(
+    start_date = BackupValueColumn(
         verbose_name="Start Date",
         accessor="update__start_date",
-        update_accessor="content_object.start_date",
+        backup_accessor="content_object.start_date",
     )
-    end_date = ConditionalValueColumn(
+    end_date = BackupValueColumn(
         verbose_name="End Date",
         accessor="update__end_date",
-        update_accessor="content_object.end_date",
+        backup_accessor="content_object.end_date",
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -396,8 +396,8 @@ class DeploymentChangeListTable(LimitedTableBase):
 
 
 class PlatformTypeChangeListTable(LimitedTableBase):
-    parent = ConditionalValueColumn(
-        verbose_name="Parent", accessor="update__parent", update_accessor="content_object.parent"
+    parent = BackupValueColumn(
+        verbose_name="Parent", accessor="update__parent", backup_accessor="content_object.parent"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -407,8 +407,8 @@ class PlatformTypeChangeListTable(LimitedTableBase):
 
 
 class MeasurementTypeChangeListTable(LimitedTableBase):
-    parent = ConditionalValueColumn(
-        verbose_name="Parent", accessor="update__parent", update_accessor="content_object.parent"
+    parent = BackupValueColumn(
+        verbose_name="Parent", accessor="update__parent", backup_accessor="content_object.parent"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -418,8 +418,8 @@ class MeasurementTypeChangeListTable(LimitedTableBase):
 
 
 class MeasurementStyleChangeListTable(LimitedTableBase):
-    parent = ConditionalValueColumn(
-        verbose_name="Parent", accessor="update__parent", update_accessor="content_object.parent"
+    parent = BackupValueColumn(
+        verbose_name="Parent", accessor="update__parent", backup_accessor="content_object.parent"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -429,10 +429,10 @@ class MeasurementStyleChangeListTable(LimitedTableBase):
 
 
 class HomeBaseChangeListTable(LimitedTableBase):
-    location = ConditionalValueColumn(
+    location = BackupValueColumn(
         verbose_name="Location",
         accessor="update__location",
-        update_accessor="content_object.location",
+        backup_accessor="content_object.location",
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -442,8 +442,8 @@ class HomeBaseChangeListTable(LimitedTableBase):
 
 
 class FocusAreaChangeListTable(LimitedTableBase):
-    url = ConditionalValueColumn(
-        verbose_name="Url", accessor="update__url", update_accessor="content_object.url"
+    url = BackupValueColumn(
+        verbose_name="Url", accessor="update__url", backup_accessor="content_object.url"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -460,10 +460,10 @@ class SeasonChangeListTable(LimitedTableBase):
 
 
 class RepositoryChangeListTable(LimitedTableBase):
-    gcmd_uuid = ConditionalValueColumn(
+    gcmd_uuid = BackupValueColumn(
         verbose_name="GCMD UUID",
         accessor="update__gcmd_uuid",
-        update_accessor="content_object.gcmd_uuid",
+        backup_accessor="content_object.gcmd_uuid",
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -475,8 +475,8 @@ class RepositoryChangeListTable(LimitedTableBase):
 
 
 class MeasurementRegionChangeListTable(LimitedTableBase):
-    example = ConditionalValueColumn(
-        verbose_name="Example", accessor="update__example", update_accessor="content_object.example"
+    example = BackupValueColumn(
+        verbose_name="Example", accessor="update__example", backup_accessor="content_object.example"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -486,8 +486,8 @@ class MeasurementRegionChangeListTable(LimitedTableBase):
 
 
 class GeographicalRegionChangeListTable(LimitedTableBase):
-    example = ConditionalValueColumn(
-        verbose_name="Example", accessor="update__example", update_accessor="content_object.example"
+    example = BackupValueColumn(
+        verbose_name="Example", accessor="update__example", backup_accessor="content_object.example"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -497,8 +497,8 @@ class GeographicalRegionChangeListTable(LimitedTableBase):
 
 
 class GeophysicalConceptChangeListTable(LimitedTableBase):
-    example = ConditionalValueColumn(
-        verbose_name="Example", accessor="update__example", update_accessor="content_object.example"
+    example = BackupValueColumn(
+        verbose_name="Example", accessor="update__example", backup_accessor="content_object.example"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -508,8 +508,8 @@ class GeophysicalConceptChangeListTable(LimitedTableBase):
 
 
 class PartnerOrgChangeListTable(LimitedTableBase):
-    website = ConditionalValueColumn(
-        verbose_name="Website", accessor="update__website", update_accessor="content_object.website"
+    website = BackupValueColumn(
+        verbose_name="Website", accessor="update__website", backup_accessor="content_object.website"
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -541,10 +541,10 @@ class WebsiteTypeChangeListTable(LimitedTableBase):
 
 
 class CampaignChangeListTable(LimitedTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="latest_update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=(
             "canonical-redirect",
             {
@@ -555,10 +555,10 @@ class CampaignChangeListTable(LimitedTableBase):
             },
         ),
     )
-    funding_agency = ConditionalValueColumn(
+    funding_agency = BackupValueColumn(
         verbose_name="Funding Agency",
         accessor="latest_update__funding_agency",
-        update_accessor="content_object.funding_agency",
+        backup_accessor="content_object.funding_agency",
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -572,10 +572,10 @@ class CampaignChangeListTable(LimitedTableBase):
 
 
 class PlatformChangeListTable(LimitedTableBase):
-    platform_type = ConditionalValueColumn(
+    platform_type = BackupValueColumn(
         verbose_name="Platform Type",
         accessor="platform_type_name",
-        update_accessor="content_object.platform_type",
+        backup_accessor="content_object.platform_type",
     )
 
     class Meta(LimitedTableBase.Meta):
@@ -625,10 +625,10 @@ class InstrumentChangeListTable(LimitedTableBase):
 
 # TODO: does this actually need to link to the campaign detail page?
 class ChangeSummaryTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
     content_type__model = tables.Column(
@@ -662,20 +662,20 @@ class ChangeSummaryTable(DraftTableBase):
 
 
 class WebsiteChangeListTable(DraftTableBase):
-    title = ConditionalValueColumn(
+    title = BackupValueColumn(
         verbose_name="Title",
         accessor="update__title",
-        update_accessor="content_object.title",
+        backup_accessor="content_object.title",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    url = ConditionalValueColumn(
-        verbose_name="URL", accessor="update__url", update_accessor="content_object.url"
+    url = BackupValueColumn(
+        verbose_name="URL", accessor="update__url", backup_accessor="content_object.url"
     )
     website_type = ShortNamefromUUIDColumn(
         verbose_name="Website Type",
         model=WebsiteType,
         accessor="update__website_type",
-        update_accessor="content_object.website_type",
+        backup_accessor="content_object.website_type",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -685,17 +685,17 @@ class WebsiteChangeListTable(DraftTableBase):
 
 
 class AliasChangeListTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
     # TODO replace model_type which short_name of related object
-    model_type = ConditionalValueColumn(
+    model_type = BackupValueColumn(
         verbose_name="Item Type",
         accessor="update__model_name",
-        update_accessor="content_object.model_name",
+        backup_accessor="content_object.model_name",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -705,19 +705,19 @@ class AliasChangeListTable(DraftTableBase):
 
 
 class GcmdProjectChangeListTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    long_name = ConditionalValueColumn(
+    long_name = BackupValueColumn(
         verbose_name="Long Name",
         accessor="update__long_name",
-        update_accessor="content_object.long_name",
+        backup_accessor="content_object.long_name",
     )
-    bucket = ConditionalValueColumn(
-        verbose_name="Bucket", accessor="update__bucket", update_accessor="content_object.bucket"
+    bucket = BackupValueColumn(
+        verbose_name="Bucket", accessor="update__bucket", backup_accessor="content_object.bucket"
     )
 
     class Meta(DraftTableBase.Meta):
@@ -727,36 +727,36 @@ class GcmdProjectChangeListTable(DraftTableBase):
 
 
 class GcmdInstrumentChangeListTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    long_name = ConditionalValueColumn(
+    long_name = BackupValueColumn(
         verbose_name="Long Name",
         accessor="update__long_name",
-        update_accessor="content_object.long_name",
+        backup_accessor="content_object.long_name",
     )
-    instrument_category = ConditionalValueColumn(
+    instrument_category = BackupValueColumn(
         verbose_name="Instrument Category",
         accessor="update__instrument_category",
-        update_accessor="content_object.instrument_category",
+        backup_accessor="content_object.instrument_category",
     )
-    instrument_class = ConditionalValueColumn(
+    instrument_class = BackupValueColumn(
         verbose_name="Instrument Class",
         accessor="update__instrument_class",
-        update_accessor="content_object.instrument_class",
+        backup_accessor="content_object.instrument_class",
     )
-    instrument_type = ConditionalValueColumn(
+    instrument_type = BackupValueColumn(
         verbose_name="Instrument Type",
         accessor="update__instrument_type",
-        update_accessor="content_object.instrument_type",
+        backup_accessor="content_object.instrument_type",
     )
-    instrument_subtype = ConditionalValueColumn(
+    instrument_subtype = BackupValueColumn(
         verbose_name="Instrument Subtype",
         accessor="update__instrument_subtype",
-        update_accessor="content_object.instrument_subtype",
+        backup_accessor="content_object.instrument_subtype",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -773,21 +773,21 @@ class GcmdInstrumentChangeListTable(DraftTableBase):
 
 
 class GcmdPlatformChangeListTable(DraftTableBase):
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="Short Name",
         accessor="update__short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    long_name = ConditionalValueColumn(
+    long_name = BackupValueColumn(
         verbose_name="Long Name",
         accessor="update__long_name",
-        update_accessor="content_object.long_name",
+        backup_accessor="content_object.long_name",
     )
-    category = ConditionalValueColumn(
+    category = BackupValueColumn(
         verbose_name="Category",
         accessor="update__category",
-        update_accessor="content_object.category",
+        backup_accessor="content_object.category",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -797,32 +797,32 @@ class GcmdPlatformChangeListTable(DraftTableBase):
 
 
 class GcmdPhenomenonChangeListTable(DraftTableBase):
-    variable_3 = ConditionalValueColumn(
+    variable_3 = BackupValueColumn(
         verbose_name="Variable 3",
         accessor="update__variable_3",
-        update_accessor="content_object.variable_3",
+        backup_accessor="content_object.variable_3",
         linkify=("change-update", [tables.A("uuid")]),
     )
-    variable_2 = ConditionalValueColumn(
+    variable_2 = BackupValueColumn(
         verbose_name="Variable 2",
         accessor="update__variable_2",
-        update_accessor="content_object.variable_2",
+        backup_accessor="content_object.variable_2",
     )
-    variable_1 = ConditionalValueColumn(
+    variable_1 = BackupValueColumn(
         verbose_name="Variable 1",
         accessor="update__variable_1",
-        update_accessor="content_object.variable_1",
+        backup_accessor="content_object.variable_1",
     )
-    term = ConditionalValueColumn(
-        verbose_name="Term", accessor="update__term", update_accessor="content_object.term"
+    term = BackupValueColumn(
+        verbose_name="Term", accessor="update__term", backup_accessor="content_object.term"
     )
-    topic = ConditionalValueColumn(
-        verbose_name="Topic", accessor="update__topic", update_accessor="content_object.topic"
+    topic = BackupValueColumn(
+        verbose_name="Topic", accessor="update__topic", backup_accessor="content_object.topic"
     )
-    category = ConditionalValueColumn(
+    category = BackupValueColumn(
         verbose_name="Category",
         accessor="update__category",
-        update_accessor="content_object.category",
+        backup_accessor="content_object.category",
     )
 
     class Meta(DraftTableBase.Meta):
@@ -854,26 +854,26 @@ class GcmdSyncListTable(DraftTableBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    short_name = ConditionalValueColumn(
+    short_name = BackupValueColumn(
         verbose_name="GCMD Keyword",
         accessor="short_name",
-        update_accessor="content_object.short_name",
+        backup_accessor="content_object.short_name",
         linkify=("change-gcmd", [tables.A("uuid")]),
     )
-    category = ConditionalValueColumn(
+    category = BackupValueColumn(
         verbose_name="Category",
         accessor="content_type__model",
-        update_accessor="content_type__model",
+        backup_accessor="content_type__model",
     )
-    draft_action = ConditionalValueColumn(
+    draft_action = BackupValueColumn(
         verbose_name="Type of Change",
         accessor="action",
-        update_accessor="action",
+        backup_accessor="action",
     )
-    status = ConditionalValueColumn(
+    status = BackupValueColumn(
         verbose_name="Status",
         accessor="status",
-        update_accessor="status",
+        backup_accessor="status",
     )
     affected_records = AffectedRecordValueColumn(
         verbose_name="Affected Records",
@@ -904,10 +904,10 @@ class GcmdSyncListTable(DraftTableBase):
 
 
 class ImageChangeListTable(DraftTableBase):
-    title = ConditionalValueColumn(
+    title = BackupValueColumn(
         verbose_name="Title",
         accessor="update__title",
-        update_accessor="content_object.title",
+        backup_accessor="content_object.title",
         linkify=("change-update", [tables.A("uuid")]),
     )
 

--- a/app/admin_ui/tests/test_views/test_published.py
+++ b/app/admin_ui/tests/test_views/test_published.py
@@ -27,38 +27,38 @@ class TestPublished:
 class TestShortNameFromUUIDColumn:
     def test_get_names_from_concrete_model(self):
         campaign = CampaignFactory()
-        column = ShortNamefromUUIDColumn(Campaign)
+        column = ShortNamefromUUIDColumn(model=Campaign, backup_accessor='')
         assert column.get_short_names([str(campaign.uuid)])[0] == campaign.short_name
 
     def test_get_name_from_concrete_model(self):
         campaign = CampaignFactory()
-        column = ShortNamefromUUIDColumn(Campaign)
+        column = ShortNamefromUUIDColumn(model=Campaign, backup_accessor='')
         assert column.get_short_name(str(campaign.uuid)) == campaign.short_name
 
     def test_get_names_from_change_model(self):
         change = ChangeFactory.make_create_change_object(
             CampaignFactory, custom_fields={"short_name": "test"}
         )
-        column = ShortNamefromUUIDColumn(Campaign)
+        column = ShortNamefromUUIDColumn(model=Campaign, backup_accessor='')
         assert column.get_short_names([str(change.uuid)])[0] == change.update["short_name"]
 
     def test_get_name_from_change_model(self):
         change = ChangeFactory.make_create_change_object(
             CampaignFactory, custom_fields={"short_name": "test"}
         )
-        column = ShortNamefromUUIDColumn(Campaign)
+        column = ShortNamefromUUIDColumn(model=Campaign, backup_accessor='')
         assert column.get_short_name(str(change.uuid)) == change.update["short_name"]
 
     def test_get_names_from_non_uuid_values(self):
         """
         Should return the provided values intact
         """
-        column = ShortNamefromUUIDColumn(Campaign)
+        column = ShortNamefromUUIDColumn(model=Campaign, backup_accessor='')
         assert column.get_short_names(["test"]) == ["test"]
 
     def test_get_name_from_non_uuid_value(self):
         """
         Should return the provided value intact
         """
-        column = ShortNamefromUUIDColumn(Campaign)
+        column = ShortNamefromUUIDColumn(model=Campaign, backup_accessor='')
         assert column.get_short_name("test") == "test"

--- a/app/admin_ui/views/v2.py
+++ b/app/admin_ui/views/v2.py
@@ -98,11 +98,8 @@ class CanonicalRecordList(mixins.DynamicModelMixin, SingleTableMixin, FilterView
         ).order_by("-updated_at")
 
         queryset = (
-            (
-                Change.objects.filter(action=Change.Actions.CREATE).of_type(
-                    self._model_config['model']
-                )
-            )
+            Change.objects.filter(action=Change.Actions.CREATE)
+            .of_type(self._model_config['model'])
             .annotate(
                 draft_uuid=Subquery(related_drafts.values("uuid")[:1]),
                 latest_status=Subquery(related_drafts.values("status")[:1]),


### PR DESCRIPTION
## What I'm changing

### Bug 1

Redirecting to new different view...

### Bug 2

Backup value wasn't being displayed.

## How I did it

1. Remove `CanonicalDraftEdit.get()` for simplicity. Not sure why needed.  In general, if UUID is in URL, that's the record we should return.  The unique redirect logic was causing Bug 1: https://github.com/NASA-IMPACT/admg-backend/blob/1741e810df99eca522d117ec73988dc291b09076/app/admin_ui/views/v2.py#L240-L250
2. Simplify & cache `CanonicalDraftEdit.get_object()`.  Lots was going on there but it wasn't entirely clear to me why.
3. Remove check for `getattr(record, "action", None) != Change.Actions.CREATE`.  This would never hit because we were using a queryset of only CREATE drafts: https://github.com/NASA-IMPACT/admg-backend/blob/1741e810df99eca522d117ec73988dc291b09076/app/admin_ui/views/v2.py#L101


---

Closes #555 