### PR TITLE
Ensure short_name is visibile on unpublished CREATE drafts in Canonical workflow

### DIFF
--- a/app/admin_ui/tables/tables.py
+++ b/app/admin_ui/tables/tables.py
@@ -44,7 +44,7 @@ class BackupValueColumn(tables.Column):
             value (str): A value which will be displayed in the table
         """
         if value is None or value == '':
-            value = A(self.update_accessor).resolve(record)
+            value = A(self.backup_accessor).resolve(record)
 
         return self._get_processed_value(value) or "---"
 


### PR DESCRIPTION
### What I'm Changing

Currently, our (poorly named) `ConditionalValueColumn` isn't properly rendering the fallback value for columns of the `Campaign` table

### Before

<img width="1076" alt="image" src="https://github.com/NASA-IMPACT/admg-backend/assets/897290/8e3199fb-8628-4346-99e0-896ab95e9b4c">

### After
<img width="1076" alt="image" src="https://github.com/NASA-IMPACT/admg-backend/assets/897290/c3160247-3db2-4561-a420-271504ec23f2">


### How I did It

To serve only Canonical drafts, the `feature/canonincal-mi-workflow` Canonical Redcord List only looks for `CREATE` drafts when rendering our list views:

https://github.com/NASA-IMPACT/admg-backend/blob/03687abf9117cdf6fb4fe211461f105f8785134e/app/admin_ui/views/v2.py#L99-L104

However, our custom fallback column on our tables only look up the fallback value if the draft was _not_ a `CREATE` draft:

https://github.com/NASA-IMPACT/admg-backend/blob/03687abf9117cdf6fb4fe211461f105f8785134e/app/admin_ui/tables/tables.py#L50

The fix was to remove this check from the fallback column.  

#### Along the way...

While dissecting how the fallback column works, I realized the column logic was unnecessarily complicated and I trimmed it down to a simpler form (which should be functionally equivalent, aside from the check for `CREATE` drafts).

---

Relates to #555