### PR TITLE
Correctly display related draft status

### DIFF
--- a/app/admin_ui/tables/tables.py
+++ b/app/admin_ui/tables/tables.py
@@ -180,7 +180,9 @@ class DraftTableBase(tables.Table):
             "badge-warning",
         ][value]
         return mark_safe(
-            f'<div class="badge badge-pill text-white {css_class}">{record.get_status_display()}</div>'
+            f'<div class="badge badge-pill text-white {css_class}">'
+            + record.__class__(status=value).get_status_display()
+            + '</div>'
         )
 
 


### PR DESCRIPTION
## What I'm Changing

I noticed that we were displaying the incorrect label on the Status column.  The color of the third record demonstrates an "In Progress" draft, however the wording states that it's published.

### Before

<img width="1073" alt="image" src="https://github.com/NASA-IMPACT/admg-backend/assets/897290/e92f36f1-b1cd-478a-a2e2-99d72a39be6e">


### After

<img width="883" alt="image" src="https://github.com/NASA-IMPACT/admg-backend/assets/897290/97eaf4e1-6740-4ac8-bbd1-bc6440d3958c">

## How I did it

This occurred because we were displaying the status of the _canonical_ draft, which is not necessarily the latest draft.  We're using the `latest_status` value to store the status of the latest draft, so we can use that to determine the display string for that status.

https://github.com/NASA-IMPACT/admg-backend/blob/03687abf9117cdf6fb4fe211461f105f8785134e/app/admin_ui/tables/tables.py#L153