### PR TITLE
Render draft action rather than approval log action

### DIFF
--- a/app/admin_ui/tables/tables.py
+++ b/app/admin_ui/tables/tables.py
@@ -920,13 +920,14 @@ class ImageChangeListTable(DraftTableBase):
 
 # This table renders a list of historical drafts
 class DraftHistoryTable(tables.Table):
-    draft_action = tables.Column(empty_values=())
+    draft_action = tables.Column(accessor=tables.A('action'))
     submitted_by = tables.Column(empty_values=())
     reviewed_by = tables.Column(empty_values=())
     published_by = tables.Column(empty_values=())
     published_date = tables.Column(empty_values=())
 
     uuid = tables.Column(
+        verbose_name="UUID",
         linkify=(
             lambda record: reverse(
                 "historical-detail",
@@ -944,9 +945,6 @@ class DraftHistoryTable(tables.Table):
         template_name = "django_tables2/bootstrap.html"
         fields = ("uuid", "submitted_by")
         orderable = False
-
-    def render_draft_action(self, record: Change):
-        return record.get_action_display()
 
     def render_submitted_by(self, record):
         if approval := record.approvallog_set.filter(action=ApprovalLog.Actions.PUBLISH).first():


### PR DESCRIPTION
I believe that it was a mistake to render our ApprovalLog status in the History table rather than the Draft status.

### Before

<img width="1075" alt="image" src="https://github.com/NASA-IMPACT/admg-backend/assets/897290/bda6227a-0a30-4efc-97d8-bee695da9674">


### After

<img width="1075" alt="image" src="https://github.com/NASA-IMPACT/admg-backend/assets/897290/b1e15645-c787-4288-a66a-285161b53b67">
