### PR TITLE
Redirect to canonical_uuid after publishing rather than URL PK

### DIFF
--- a/app/admin_ui/views/change.py
+++ b/app/admin_ui/views/change.py
@@ -512,7 +512,7 @@ class ChangeTransition(NotificationSidebar, FormMixin, ProcessFormView, DetailVi
         return reverse(
             "canonical-redirect",
             kwargs={
-                "canonical_uuid": self.kwargs[self.pk_url_kwarg],
+                "canonical_uuid": self.get_object().canonical_uuid,
                 "model": self.get_form().change.content_type.model,
             },
         )


### PR DESCRIPTION
Resolves #603 

We were successfully transitioning models to the Published state, but then redirecting to a view which requires the canonical UUID and passing it the draft ID. I've updated it to fix that redirect.