### PR TITLE
Updated health check settings 

### DIFF
--- a/deploy/deploy_stacks/app_stack.py
+++ b/deploy/deploy_stacks/app_stack.py
@@ -10,6 +10,7 @@ from aws_cdk import (
     aws_s3 as s3,
     Stack,
     App,
+    Duration,
     aws_ecs_patterns as patterns,
 )
 import pydantic
@@ -118,7 +119,13 @@ class ApplicationStack(Stack):
             ),
         )
 
-        app_service.target_group.configure_health_check(path="/accounts/login/")
+        app_service.target_group.configure_health_check(
+            path="/accounts/login/",
+            healthy_threshold_count=2,
+            unhealthy_threshold_count=2,
+            timeout=Duration.seconds(30),
+            interval=Duration.seconds(10),
+        )
 
         # Create a Fargate service that runs the Celery worker
         worker_service = patterns.QueueProcessingFargateService(


### PR DESCRIPTION
On almost every deployment, new healthy containers are being killed by the load balancer target group due to failed health checks. I'm guessing the culprit is timed out health check requests, since the containers are perfectly health, but probably a little slow to respond. Eventually a new container starts up and passes the health check, allowing the deployment to succeed, but we're wasting time and github actions minutes just waiting for them to be restarted.

I've increased the timeout and also reduced the number of healthy checks required to call a container health, all of which should speed up the deployments.