### PR TITLE
Don't Merge Me...except non-existent changes

### DIFF
--- a/api_app/models.py
+++ b/api_app/models.py
@@ -843,7 +843,10 @@ def set_change_updated_at(sender, instance, **kwargs):
     Set `updated_at` on the related Change object to the value of
     the ApprovalLog's `date` field.
     """
-    Change.objects.filter(pk=instance.change.pk).update(updated_at=instance.date)
+    try:
+        Change.objects.filter(pk=instance.change.pk).update(updated_at=instance.date)
+    except Change.DoesNotExist:
+        pass
 
 
 class Recommendation(models.Model):


### PR DESCRIPTION
Don't actually merge this pr.
It looks like `api_app/models.py` `set_change_updated_at` was blocking database load when it hits a bad change link. 

If you want to load the database on local, 
- check out this branch
- delete pre-existing docker volumes and containers
- rebuild the docker
- enter the webapp container and `python manage.py loaddata` 

Here is the link to the [prod backup](https://drive.google.com/file/d/1un9ngakzcs1ZXj6Tre2q741NI1eOLGi6/view?usp=sharing)

I'm a bit worried that we have badly linked change objects in prod that are causing this. It would be worth doing an investigation of the change objects to see what's going on.