### PR TITLE
Updated the README.md by removing the ER diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 
 # `admg_webapp` backend documentation
 
-## ER Diagrams
-
-Entity Relationship Diagrams can be found at this [link](https://drive.google.com/drive/folders/1_Zr_ZP97Tz8hBk5wxEpLmZ8Es2umJvjh)
-
 ## How to use the interactive Query
 
 ```


### PR DESCRIPTION
Removed the ER diagrams. Users would have to request access to IMPACT drive. Also this doesn't fit align well with the message of the readme.